### PR TITLE
GetSecretsWithData now returns the data for registries, fixed following panic with invalid authentication

### DIFF
--- a/pkg/direktiv/state-logic-action.go
+++ b/pkg/direktiv/state-logic-action.go
@@ -185,7 +185,7 @@ func (sl *actionStateLogic) Run(ctx context.Context, instance *workflowLogicInst
 			ar.Container.Registries = make(map[string]string)
 
 			// get registries
-			ar.Container.Registries, err = getRegistries(instance.engine.server.config,
+			ar.Container.Registries, err = getRegistries(instance.engine.server.dbManager, instance.engine.server.config,
 				instance.engine.secretsClient, instance.namespace)
 			if err != nil {
 				return
@@ -203,7 +203,7 @@ func (sl *actionStateLogic) Run(ctx context.Context, instance *workflowLogicInst
 					ar.Workflow.Step = 0
 
 					// get registries
-					ar.Container.Registries, err = getRegistries(instance.engine.server.config,
+					ar.Container.Registries, err = getRegistries(instance.engine.server.dbManager, instance.engine.server.config,
 						instance.engine.secretsClient, instance.namespace)
 					if err != nil {
 						return

--- a/pkg/direktiv/state-logic-foreach.go
+++ b/pkg/direktiv/state-logic-foreach.go
@@ -168,7 +168,7 @@ func (sl *foreachStateLogic) Run(ctx context.Context, instance *workflowLogicIns
 				ar.Container.Data = inputData
 
 				// get registries
-				ar.Container.Registries, err = getRegistries(instance.engine.server.config,
+				ar.Container.Registries, err = getRegistries(instance.engine.server.dbManager, instance.engine.server.config,
 					instance.engine.secretsClient, instance.namespace)
 				if err != nil {
 					return

--- a/pkg/direktiv/state-logic-parallel.go
+++ b/pkg/direktiv/state-logic-parallel.go
@@ -151,7 +151,7 @@ func (sl *parallelStateLogic) dispatchActions(ctx context.Context, instance *wor
 			ar.Container.Data = inputData
 
 			// get registries
-			ar.Container.Registries, err = getRegistries(instance.engine.server.config,
+			ar.Container.Registries, err = getRegistries(instance.engine.server.dbManager, instance.engine.server.config,
 				instance.engine.secretsClient, instance.namespace)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Description

Makes GetSecretsWithData return data, Fixes a panic following that to do with invalid authentication when pointing to an external registry.

## Purpose

- [X] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Connected to marketplace.gcr.io with service account and a 60 minute access token
