### PR TITLE
direktiv resetAll script updated to remove old ip addresses

### DIFF
--- a/scripts/resetAll.sh
+++ b/scripts/resetAll.sh
@@ -20,6 +20,7 @@ echo "deleting k3s data"
 
 rm -Rf /etc/rancher/k3s
 rm -Rf /var/lib/rancher/k3s
+rm -rf /var/lib/cni/networks/cbr0
 
 echo "starting k3s"
 


### PR DESCRIPTION
Signed-off-by: Jon Alfaro <jon.alfaro@vorteil.io>

## Description

IP addresses are not getting cleaned up when using the `resetAll` script. This will cause k8s to run out of addresses if the `resetAll` script is executed enough times.
