### PR TITLE
Authorization apiKey added to api and helm chart

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,10 +1,20 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"net/http"
+	"os"
+	"strings"
 
 	"github.com/vorteil/direktiv/pkg/api"
 )
+
+// Envrioment Value Name for Manual apikey
+const API_KEY_ENV = "DIREKTIV_API_KEY"
+
+// apiKey to be used for simple apikey auth
+var apiKey = ""
 
 func main() {
 
@@ -18,9 +28,45 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
+	// Enabled simple apikey auth if env is set
+	apiKey = os.Getenv(API_KEY_ENV)
+	if len(apiKey) > 0 {
+		fmt.Println("apiKey auth mode enabled")
+		s.Router().Use(APIAuthMiddleware)
+	}
+
 	err = s.Start()
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 
+}
+
+// API Auth Middleware
+func APIAuthMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Allow preflight Options
+		if r.Method == "OPTIONS" {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		// Get Auth token
+		reqToken := r.Header.Get("Authorization")
+		splitToken := strings.Split(reqToken, "apikey")
+		if len(splitToken) != 2 {
+			w.WriteHeader(401)
+			w.Write([]byte("apikey Token is malformed"))
+			return
+		}
+
+		reqToken = strings.TrimSpace(splitToken[1])
+
+		if reqToken != apiKey {
+			w.WriteHeader(401)
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	})
 }

--- a/kubernetes/charts/direktiv/templates/api-deployment.yaml
+++ b/kubernetes/charts/direktiv/templates/api-deployment.yaml
@@ -45,6 +45,14 @@ spec:
       containers:
       - name: api
         image: "{{ .Values.registry }}/{{ .Values.api.image }}:{{ .Values.api.tag | default .Chart.AppVersion }}"
+        env:
+          {{- if  .Values.api.key }}
+          - name: DIREKTIV_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "direktiv.fullname" . }}
+                key: apiKey
+          {{- end }}
         volumeMounts:
         - name: apiconf
           mountPath: "/config"

--- a/kubernetes/charts/direktiv/templates/secrets.yaml
+++ b/kubernetes/charts/direktiv/templates/secrets.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "direktiv.labels" . | nindent 4 }}
 type: Opaque
 data:
+  apiKey: {{ .Values.api.key | b64enc | quote }}
   {{- if .Values.flow.db }}
   db: {{ .Values.flow.db | b64enc | quote }}
   {{- else }}

--- a/kubernetes/charts/direktiv/values.yaml
+++ b/kubernetes/charts/direktiv/values.yaml
@@ -115,5 +115,6 @@ ui:
 api:
   image: vorteil/api
   tag: "latest"
+  key: ""
 
 uiapiCertificate: none


### PR DESCRIPTION
Signed-off-by: Jon Alfaro <jon.alfaro@vorteil.io>

## Description

Support added to Authorization apiKey for the api binary. This auth step is optional and can enabled by passing the DIREKTIV_API_KEY environment. Helm has been setup to pass this env as a secret also.
