### PR TITLE
Added a new log to namespace for broadcasting events.

### DIFF
--- a/pkg/api/namespace.go
+++ b/pkg/api/namespace.go
@@ -1,10 +1,10 @@
 package api
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 
+	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 	"github.com/vorteil/direktiv/pkg/ingress"
@@ -105,19 +105,10 @@ func (h *Handler) namespaceEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var contentType string
-	if typeMap, ok := r.Header["Content-Type"]; ok {
-		contentType = typeMap[0]
-	}
-
-	switch contentType {
-	case "application/cloudevents+json; charset=utf-8":
-	case "application/cloudevents+json":
-	case "application/json; charset=utf-8":
-	case "application/json":
-		break
-	default:
-		ErrResponse(w, fmt.Errorf("content type '%s' is not supported. supported media types: 'application/json' ", contentType))
+	event := new(cloudevents.Event)
+	err = event.UnmarshalJSON(b)
+	if err != nil {
+		ErrResponse(w, err)
 		return
 	}
 

--- a/pkg/direktiv/grpc.go
+++ b/pkg/direktiv/grpc.go
@@ -141,8 +141,16 @@ func (is *ingressServer) BroadcastEvent(ctx context.Context, in *ingress.Broadca
 	}
 
 	log.Debugf("Broadcasting event on namespace '%s': %s/%s", namespace, event.Type(), event.Source())
+	dlogger, err := is.wfServer.instanceLogger.NamespaceLogger(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	dlogger.Info(fmt.Sprintf("Broadcasting event: type=%s, source=%s", event.Type(), event.Source()))
 
 	err = is.wfServer.handleEvent(*in.Namespace, event)
+
+	dlogger.Close()
 
 	return &resp, err
 


### PR DESCRIPTION
- logs the type and source for the cloud event
- unmarshals the cloud event on the api handler to handle validation
