### PR TITLE
Catch error wildcard

### DIFF
--- a/pkg/direktiv/engine.go
+++ b/pkg/direktiv/engine.go
@@ -973,7 +973,12 @@ failure:
 			var matched bool
 
 			// NOTE: this error should be checked in model validation
-			matched, _ = regexp.MatchString(catch.Error, cerr.Code)
+			errRegex := catch.Error
+			if errRegex == "*" {
+				errRegex = ".*"
+			}
+
+			matched, _ = regexp.MatchString(errRegex, cerr.Code)
 
 			if matched {
 


### PR DESCRIPTION
When checking for catchable errors, treat '\*' as '\.\*' to match any catchable error.