### PR TITLE
Include DB connection info in Sidecar CM, and allow for setting indep…

### DIFF
--- a/kubernetes/charts/direktiv/templates/secrets.yaml
+++ b/kubernetes/charts/direktiv/templates/secrets.yaml
@@ -8,6 +8,11 @@ metadata:
 type: Opaque
 data:
   apiKey: {{ .Values.api.key | b64enc | quote }}
+  {{- if .Values.flow.sidecarDb }}
+  sidecarDb: {{ .Values.flow.sidecarDb | b64enc | quote }}
+  {{- else }}
+  sidecarDb: {{ printf "host=%s-support port=5432 user=direktiv dbname=direktiv password=direktivdirektiv sslmode=disable" ( include "direktiv.fullname" . )  | b64enc | quote }}
+  {{- end }}
   {{- if .Values.flow.db }}
   db: {{ .Values.flow.db | b64enc | quote }}
   {{- else }}

--- a/kubernetes/charts/direktiv/templates/sidecar-cm.yaml
+++ b/kubernetes/charts/direktiv/templates/sidecar-cm.yaml
@@ -52,6 +52,15 @@ data:
                 "name": "direktiv-sidecar",
                 "env": [
                   {
+                    "name": "DIREKTIV_DB",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "{{ include "direktiv.fullname" . }}",
+                        "key": "sidecarDb"
+                      }
+                    }
+                  },
+                  {
                     "name": "DIREKTIV_DEBUG",
                     "value": "{{ .Values.debug }}"
                   },

--- a/kubernetes/charts/direktiv/values.yaml
+++ b/kubernetes/charts/direktiv/values.yaml
@@ -105,6 +105,7 @@ flow:
   tag: "latest"
   exchange: "checkMe"
   sidecar: "vorteil/sidecar"
+  sidecarDb: ""
   db: ""
   protocol: "http"
   certificate: none


### PR DESCRIPTION
This will impact people using custom helm config files when performing a helm install, if not using the 'default' DB connection info (which, if not provided, defaults to the same connection info as the existing flow.db default value).