### PR TITLE
Added namespace filtering to prevent badwords and reserved words

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	entgo.io/ent v0.8.0
+	github.com/TwinProduction/go-away v1.1.4 // indirect
 	github.com/apoorvam/goterminal v0.0.0-20180523175556-614d345c47e5 // indirect
 	github.com/banzaicloud/logrus-runtime-formatter v0.0.0-20190729070250-5ae5475bae5e
 	github.com/cloudevents/sdk-go v1.2.0
@@ -39,6 +40,7 @@ require (
 	github.com/vorteil/direktiv-apps v0.0.0-20210423031131-1bc5000144a1
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4
+	golang.org/x/text v0.3.6 // indirect
 	google.golang.org/grpc v1.36.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/TwinProduction/go-away v1.1.4 h1:U/jTVXIJr+vQKXirbrI5yrkPF3Y/S/hia2EhXKIJIQA=
+github.com/TwinProduction/go-away v1.1.4/go.mod h1:rhlrmkf0W6BXWsJoj96OYT0FU/Z7mtvfrAW3JezrWeA=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
@@ -1062,6 +1064,8 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/kubernetes/charts/direktiv/templates/api-blocklistnamespaces-cm.yaml
+++ b/kubernetes/charts/direktiv/templates/api-blocklistnamespaces-cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  blocklist: |-
+    ["grafana", "tempo", "loki", "auth", "jaegar"]
+kind: ConfigMap
+metadata:
+  name: api-blocklistnamespaces-cm

--- a/kubernetes/charts/direktiv/templates/api-cfg-cm.yaml
+++ b/kubernetes/charts/direktiv/templates/api-cfg-cm.yaml
@@ -9,6 +9,8 @@ data:
     {{ . }}
     {{ end }}
 
+    blockList = "blocklist"
+
     [ingress]
       endpoint = "direktiv-kube:///{{ include "direktiv.fullname" . }}-ingress.{{ .Release.Namespace }}:6666"
       {{- if ne .Values.ingress.certificate "none" }}

--- a/kubernetes/charts/direktiv/templates/api-deployment.yaml
+++ b/kubernetes/charts/direktiv/templates/api-deployment.yaml
@@ -33,6 +33,12 @@ spec:
       - name: wf-templates
         configMap:
           name: api-wftemplates-cm
+      - name: api-blocklist
+        configMap:
+          name: api-blocklistnamespaces-cm
+          items:
+          - key: blocklist
+            path: blocklist
       - name: action-templates
         configMap:
           name: api-actiontemplates-cm
@@ -86,6 +92,9 @@ spec:
         - name: apiconf
           mountPath: "/config"
           readOnly: true
+        - name: api-blocklist
+          mountPath: /blocklist
+          subPath: "blocklist"
         - name: wf-templates
           mountPath: "/tmp/workflow-templates"
         - name: action-templates

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -20,6 +20,7 @@ type Config struct {
 		Bind string
 	}
 
+	BlockList string // path to where the blocklist for reserved words will be
 	Templates struct {
 		WorkflowTemplateDirectories []NamedDirectory
 		ActionTemplateDirectories   []NamedDirectory
@@ -130,6 +131,13 @@ func Configure() (*Config, error) {
 
 	return cfg, err
 
+}
+
+func (c *Config) hasBlockList() bool {
+	if c.BlockList == "" {
+		return false
+	}
+	return true
 }
 
 func (c *Config) hasWorkflowTemplateDefault() bool {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -43,19 +43,24 @@ type Server struct {
 func NewServer(cfg *Config) (*Server, error) {
 
 	r := mux.NewRouter()
-
-	// fetch blocklist
 	var bl []string
-	data, err := ioutil.ReadFile(blocklist)
-	if err != nil {
-		return nil, err
-	}
-	err = json.Unmarshal(data, &bl)
-	if err != nil {
-		return nil, err
-	}
 
-	log.Infof("blocklist %s", data)
+	log.Infof("check for a blocklist")
+
+	if cfg.hasBlockList() {
+		log.Infof("contains a blocklist")
+		// fetch blocklist
+		data, err := ioutil.ReadFile(cfg.BlockList)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(data, &bl)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Infof("blocklist %s", data)
+	}
 
 	s := &Server{
 		cfg:    cfg,
@@ -76,7 +81,7 @@ func NewServer(cfg *Config) (*Server, error) {
 		s: s,
 	}
 
-	err = s.initDirektiv()
+	err := s.initDirektiv()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add a new configmap for the API server and added a new library to handle badwords. 

- First filter swearing
- Restrict creation of namespaces where the name exactly matches a reserved word (for example: 'api').