### PR TITLE
Logic fix to stop incorrectly causing internal error when instance status is error

### DIFF
--- a/pkg/direktiv/wli.go
+++ b/pkg/direktiv/wli.go
@@ -175,7 +175,7 @@ func (we *workflowEngine) loadWorkflowLogicInstance(id string, step int) (contex
 		return ctx, nil, NewInternalError(fmt.Errorf("cannot load saved workflow definition: %v", err))
 	}
 
-	if rec.Status != "pending" && rec.Status != "running" {
+	if !rec.EndTime.IsZero() {
 		wli.unlock()
 		return ctx, nil, NewInternalError(fmt.Errorf("aborting workflow logic: database records instance terminated"))
 	}


### PR DESCRIPTION
… status

Signed-off-by: Jon Alfaro <jon.alfaro@vorteil.io>

## Description

When calling a error state in an instance, the instance status will be set to error. However the workflow should be able to continue, and should not cause a internal error. This changes checking instance status to checking instance endtime when reporting results.

## Purpose

- [X] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Tested with a few different workflows to make sure that the result is correct.
