### PR TITLE
Internal tls

### DIFF
--- a/kubernetes/charts/direktiv/templates/api-deployment.yaml
+++ b/kubernetes/charts/direktiv/templates/api-deployment.yaml
@@ -47,10 +47,10 @@ spec:
         secret:
           secretName: {{ .Values.flow.certificate }}
       {{- end }}
-      {{- if ne  .Values.uiapiCertificate "none" }}
+      {{- if ne  .Values.flow.certificate "none" }}
       - name: servecerts
         secret:
-          secretName: {{ .Values.uiapiCertificate }}
+          secretName: {{ .Values.flow.certificate }}
       {{- end }}
       containers:
       - name: api
@@ -66,7 +66,7 @@ spec:
           httpGet:
             path: /api/healthz
             port: 8080
-            {{- if ne  .Values.uiapiCertificate "none" }}
+            {{- if ne  .Values.flow.certificate "none" }}
             scheme: HTTPS
             {{- end }}
           periodSeconds: 10
@@ -108,7 +108,7 @@ spec:
           mountPath: "/etc/certs/direktiv"
           readOnly: true
         {{- end }}
-        {{- if ne  .Values.uiapiCertificate "none" }}
+        {{- if ne  .Values.flow.certificate "none" }}
         - name: servecerts
           mountPath: "/etc/certs/servedirektiv"
           readOnly: true

--- a/kubernetes/charts/direktiv/templates/api-service.yaml
+++ b/kubernetes/charts/direktiv/templates/api-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "direktiv.fullname" . }}-api-service
   labels:
     {{- include "direktiv.labelsAPI" . | nindent 4 }}
-  {{- if ne  .Values.uiapiCertificate "none" }}
+  {{- if ne  .Values.flow.certificate "none" }}
   annotations:
     projectcontour.io/upstream-protocol.tls: "{{ include "direktiv.fullname" . }}-api-service,8080"
   {{- end }}

--- a/kubernetes/charts/direktiv/templates/ingress.yaml
+++ b/kubernetes/charts/direktiv/templates/ingress.yaml
@@ -6,11 +6,6 @@ metadata:
     {{- include "direktiv.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
-    {{- if ne  .Values.flow.certificate "none" }}
-    {{- if eq .Values.ingress.certificate "none" }}
-    kubernetes.io/ingress.allow-http: "true"
-    {{- end }}
-    {{- end }}
     {{- if ne .Values.ingress.certificate "none" }}
     ingress.kubernetes.io/force-ssl-redirect: "true"
     {{- end }}
@@ -27,11 +22,7 @@ spec:
   {{- end }}
   rules:
   - host: {{ .Values.ingress.host }}
-    {{- if ne  .Values.flow.certificate "none" }}
     http:
-    {{- else }}
-    https:
-    {{- end }}
       paths:
         - path: /api
           pathType: Prefix

--- a/kubernetes/charts/direktiv/templates/ingress.yaml
+++ b/kubernetes/charts/direktiv/templates/ingress.yaml
@@ -6,6 +6,11 @@ metadata:
     {{- include "direktiv.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+    {{- if ne  .Values.flow.certificate "none" }}
+    {{- if eq .Values.ingress.certificate "none" }}
+    kubernetes.io/ingress.allow-http: "true"
+    {{- end }}
+    {{- end }}
     {{- if ne .Values.ingress.certificate "none" }}
     ingress.kubernetes.io/force-ssl-redirect: "true"
     {{- end }}
@@ -22,7 +27,11 @@ spec:
   {{- end }}
   rules:
   - host: {{ .Values.ingress.host }}
+    {{- if ne  .Values.flow.certificate "none" }}
     http:
+    {{- else }}
+    https:
+    {{- end }}
       paths:
         - path: /api
           pathType: Prefix

--- a/kubernetes/charts/direktiv/templates/ui-deployment.yaml
+++ b/kubernetes/charts/direktiv/templates/ui-deployment.yaml
@@ -51,7 +51,7 @@ spec:
             httpGet:
               path: /manifest.json
               port: 8080
-              {{- if ne  .Values.uiapiCertificate "none" }}
+              {{- if ne  .Values.flow.certificate "none" }}
               scheme: HTTPS
               {{- end }}
             periodSeconds: 10
@@ -66,7 +66,7 @@ spec:
             value: "/api"
           - name: KEYCLOAK_URL
             value: {{ .Values.ui.keycloakUrl }}
-          {{- if ne .Values.uiapiCertificate "none" }}
+          {{- if ne .Values.flow.certificate "none" }}
           volumeMounts:
           - name: certs
             mountPath: "/etc/certs/direktiv"
@@ -78,10 +78,10 @@ spec:
               containerPort: 8080
               protocol: TCP
       volumes:
-      {{- if ne  .Values.uiapiCertificate "none" }}
+      {{- if ne  .Values.flow.certificate "none" }}
         - name: certs
           secret:
-            secretName: {{ .Values.uiapiCertificate }}
+            secretName: {{ .Values.flow.certificate }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/kubernetes/charts/direktiv/templates/ui-service.yaml
+++ b/kubernetes/charts/direktiv/templates/ui-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "direktiv.fullname" . }}-ui
   labels:
     {{- include "direktiv.labelsUI" . | nindent 4 }}
-  {{- if ne  .Values.uiapiCertificate "none" }}
+  {{- if ne  .Values.flow.certificate "none" }}
   annotations:
     projectcontour.io/upstream-protocol.tls: "{{ include "direktiv.fullname" . }}-ui,8080"
   {{- end }}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -196,11 +196,14 @@ func (s *Server) prepareRoutes() {
 
 }
 
-const tlsDir = "/etc/certs/servedirektiv"
+// const tlsDir = "/etc/certs/servedirektiv"
+const tlsDir = "/etc/certs/direktiv/"
 
 func tlsEnabled() bool {
-	_, err := os.Stat(tlsDir)
-	return !os.IsNotExist(err)
+	if _, err := os.Stat(tlsDir); err != nil {
+		return false
+	}
+	return true
 }
 
 // Start starts the API server


### PR DESCRIPTION
Setting the `flow.certificate` field in a helm config file will result in all relevant internal components using that certificate for TLS connection within the cluster. 