### PR TITLE
Add metrics gathering functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/nxadm/tail v1.4.4
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo v1.14.0 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/qri-io/jsonschema v0.2.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rung/go-safecast v1.0.1
@@ -37,10 +38,10 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go4.org v0.0.0-20201209231011-d4a079459e60 // indirect
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
-	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40
 	golang.org/x/text v0.3.6 // indirect
 	google.golang.org/grpc v1.36.0
-	google.golang.org/protobuf v1.25.0
+	google.golang.org/protobuf v1.26.0-rc.1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.19.7

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
+github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
@@ -493,6 +494,8 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
+github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -650,6 +653,8 @@ github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeD
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.9.0 h1:Rrch9mh17XcxvEu9D9DEpb4isxjGBtcevQjKvxPRQIU=
 github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
+github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
+github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -667,6 +672,8 @@ github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB8
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.19.0 h1:Itb4+NjG9wRdkAWgVucbM/adyIXxEhbw0866e0uZE6A=
 github.com/prometheus/common v0.19.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
+github.com/prometheus/common v0.26.0 h1:iMAkS2TDoNWnKM+Kopnx/8tnEStIfpYA0ur0xQzzhMQ=
+github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -678,6 +685,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULUx4=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
+github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/statsd_exporter v0.15.0 h1:UiwC1L5HkxEPeapXdm2Ye0u1vUJfTj7uwT5yydYpa1E=
 github.com/prometheus/statsd_exporter v0.15.0/go.mod h1:Dv8HnkoLQkeEjkIE4/2ndAA7WL1zHKK7WMqFQqu72rw=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
@@ -1023,6 +1032,8 @@ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7qvEEgHo3otj+HB5CM7Q=
+golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
@@ -1236,6 +1247,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+google.golang.org/protobuf v1.26.0-rc.1 h1:7QnIQpGRHE5RnLKnESfDoxm2dTapTZua5a0kS0A+VXQ=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/kubernetes/charts/direktiv/templates/_helpers.tpl
+++ b/kubernetes/charts/direktiv/templates/_helpers.tpl
@@ -119,6 +119,24 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Selector labels prometheus
+*/}}
+{{- define "direktiv.selectorLabelsPrometheus" -}}
+app.kubernetes.io/name: {{ include "direktiv.name" . }}-prometheus
+app.kubernetes.io/instance: {{ .Release.Name }}-prometheus
+{{- end }}
+
+{{- define "direktiv.labelsPrometheus" -}}
+helm.sh/chart: {{ include "direktiv.chart" . }}
+{{ include "direktiv.selectorLabelsPrometheus" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "direktiv.serviceAccountName" -}}

--- a/kubernetes/charts/direktiv/templates/flow-deployment.yaml
+++ b/kubernetes/charts/direktiv/templates/flow-deployment.yaml
@@ -15,9 +15,11 @@ spec:
   template:
     metadata:
       annotations:
-        "prometheus.io/path": "/metrics"
-        "prometheus.io/port": "2112"
-        "prometheus.io/scrape": "true"
+        {{- if .Values.flow.prometheus.enabled }}
+        "prometheus.io/path": {{ .Values.flow.prometheus.path | default "/metrics" }}
+        "prometheus.io/port": {{ .Values.flow.prometheus.port | default 2112 | quote }}
+        "prometheus.io/scrape": {{ .Values.flow.prometheus.scrape | default true | quote }}
+        {{- end }}
       labels:
         {{- include "direktiv.selectorLabels" . | nindent 8 }}
     spec:

--- a/kubernetes/charts/direktiv/templates/flow-deployment.yaml
+++ b/kubernetes/charts/direktiv/templates/flow-deployment.yaml
@@ -14,6 +14,10 @@ spec:
       {{- include "direktiv.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        "prometheus.io/path": "/metrics"
+        "prometheus.io/port": "2112"
+        "prometheus.io/scrape": "true"
       labels:
         {{- include "direktiv.selectorLabels" . | nindent 8 }}
     spec:
@@ -80,6 +84,9 @@ spec:
               protocol: TCP
             - name: flow
               containerPort: 7777
+              protocol: TCP
+            - name: metrics
+              containerPort: 2112
               protocol: TCP
           env:
           - name: DIREKTIV_DEBUG

--- a/kubernetes/charts/direktiv/templates/prometheus-cm.yaml
+++ b/kubernetes/charts/direktiv/templates/prometheus-cm.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-server-conf
+  labels:
+    name: prometheus-server-conf
+data:
+  prometheus.rules: |-
+    groups:
+    - name: devopscube demo alert
+      rules:
+      - alert: High Pod Memory
+        expr: sum(container_memory_usage_bytes) > 1
+        for: 1m
+        labels:
+          severity: slack
+        annotations:
+          summary: High Memory Usage
+  prometheus.yml: |-
+    global:
+      scrape_interval: 1m
+      evaluation_interval: 1m
+      scrape_timeout: 10s
+    rule_files:
+      - /etc/prometheus/prometheus.rules
+    scrape_configs:
+      - job_name: workflows
+        honor_timestamps: true
+        scrape_interval: 10s
+        scrape_timeout: 10s
+        metrics_path: /metrics
+        scheme: http
+        follow_redirects: true
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          separator: ;
+          regex: "true"
+          replacement: $1
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+          separator: ;
+          regex: (https?)
+          target_label: __scheme__
+          replacement: $1
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          separator: ;
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: $1
+          action: replace
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          separator: ;
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          target_label: __address__
+          replacement: $1:$2
+          action: replace
+        kubernetes_sd_configs:
+        - role: pod
+          follow_redirects: true

--- a/kubernetes/charts/direktiv/templates/prometheus-deployment.yaml
+++ b/kubernetes/charts/direktiv/templates/prometheus-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "direktiv.fullname" . }}-prometheus
+  labels:
+      {{ include "direktiv.labelsPrometheus" . | nindent 4 }}-prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "direktiv.selectorLabelsPrometheus" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "direktiv.selectorLabelsPrometheus" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "direktiv.serviceAccountName" . }}-prometheus
+      containers:
+        - name: prometheus
+          image: prom/prometheus
+          args:
+            - "--storage.tsdb.retention.time=12h"
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus/"
+          ports:
+            - containerPort: 9090
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500M
+            limits:
+              cpu: 1
+              memory: 1Gi
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus
+            - name: prometheus-storage-volume
+              mountPath: /prometheus/
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            defaultMode: 420
+            name: prometheus-server-conf
+        - name: prometheus-storage-volume
+          emptyDir: {}

--- a/kubernetes/charts/direktiv/templates/prometheus-role-ns.yaml
+++ b/kubernetes/charts/direktiv/templates/prometheus-role-ns.yaml
@@ -1,0 +1,10 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+ name: {{ include "direktiv.serviceAccountName" . }}-prometheus-role
+ labels:
+   {{- include "direktiv.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]

--- a/kubernetes/charts/direktiv/templates/prometheus-rolebind-cluster.yaml
+++ b/kubernetes/charts/direktiv/templates/prometheus-rolebind-cluster.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+ name: {{ include "direktiv.serviceAccountName" . }}-prometheus-binding
+subjects:
+- kind: ServiceAccount
+  name: {{ include "direktiv.serviceAccountName" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
+roleRef:
+ kind: ClusterRole
+ name: {{ include "direktiv.serviceAccountName" . }}-role-cluster
+ apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/charts/direktiv/templates/prometheus-rolebind-ns.yaml
+++ b/kubernetes/charts/direktiv/templates/prometheus-rolebind-ns.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+ name: {{ include "direktiv.serviceAccountName" . }}-prometheus-binding-lock
+subjects:
+- kind: ServiceAccount
+  name: {{ include "direktiv.serviceAccountName" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
+roleRef:
+ kind: Role
+ name: {{ include "direktiv.serviceAccountName" . }}-prometheus-role
+ apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/charts/direktiv/templates/prometheus-sa.yaml
+++ b/kubernetes/charts/direktiv/templates/prometheus-sa.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "direktiv.serviceAccountName" . }}-prometheus
+  labels:
+    {{- include "direktiv.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/kubernetes/charts/direktiv/templates/prometheus-service.yaml
+++ b/kubernetes/charts/direktiv/templates/prometheus-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.withAPI -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "direktiv.fullname" . }}-prometheus-service
+  labels:
+    {{- include "direktiv.labelsPrometheus" . | nindent 4 }}
+  annotations:
+    projectcontour.io/upstream-protocol.tls: "{{ include "direktiv.fullname" . }}-prometheus-service,9090"
+spec:
+  selector:
+    {{- include "direktiv.selectorLabelsPrometheus" . | nindent 4 }}
+  ports:
+    - protocol: TCP
+      port: 9090
+      targetPort: 9090
+{{- end }}

--- a/kubernetes/charts/direktiv/values.yaml
+++ b/kubernetes/charts/direktiv/values.yaml
@@ -60,6 +60,11 @@ flow:
   image: "vorteil/flow"
   tag: ""
   db: ""
+  prometheus:
+    enabled: true
+    port: 2112
+    path: /metrics
+    scrape: true
   functionsProtocol: "http"
   functionsCA: "none" # change function pod secret too
   certificates:

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+func (h *Handler) queryPrometheus(str string, t time.Time) (map[string]interface{}, error) {
+
+	v1API := v1.NewAPI(h.s.prometheus)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	res, warnings, err := v1API.Query(ctx, str, t)
+	if err != nil {
+		return nil, err
+	}
+
+	out := map[string]interface{}{
+		"warnings": warnings,
+		"results":  res,
+	}
+
+	return out, nil
+}
+
+func (h *Handler) getNamespaceMetrics_WorkflowsInvoked(w http.ResponseWriter, r *http.Request) {
+
+	out, err := h.queryPrometheus(fmt.Sprintf(`direktiv_workflows_invoked_total{namespace="%s"}`, mux.Vars(r)["namespace"]), time.Now())
+	if err != nil {
+		ErrResponse(w, err)
+		return
+	}
+
+	writeJSONResponse(w, out)
+}
+
+func (h *Handler) getNamespaceMetrics_WorkflowsSuccessful(w http.ResponseWriter, r *http.Request) {
+
+	out, err := h.queryPrometheus(fmt.Sprintf(`direktiv_workflows_success_total{namespace="%s"}`, mux.Vars(r)["namespace"]), time.Now())
+	if err != nil {
+		ErrResponse(w, err)
+		return
+	}
+
+	writeJSONResponse(w, out)
+}
+
+func (h *Handler) getNamespaceMetrics_WorkflowsFailed(w http.ResponseWriter, r *http.Request) {
+
+	out, err := h.queryPrometheus(fmt.Sprintf(`direktiv_workflows_failed_total{namespace="%s"}`, mux.Vars(r)["namespace"]), time.Now())
+	if err != nil {
+		ErrResponse(w, err)
+		return
+	}
+
+	writeJSONResponse(w, out)
+}
+
+func (h *Handler) getWorkflowMetrics_Invoked(w http.ResponseWriter, r *http.Request) {
+	out, err := h.queryPrometheus(fmt.Sprintf(`direktiv_workflows_invoked_total{namespace="%s", workflow="%s"}`, mux.Vars(r)["namespace"], mux.Vars(r)["workflow"]), time.Now())
+	if err != nil {
+		ErrResponse(w, err)
+		return
+	}
+
+	writeJSONResponse(w, out)
+}
+
+func (h *Handler) getWorkflowMetrics_Successful(w http.ResponseWriter, r *http.Request) {
+	out, err := h.queryPrometheus(fmt.Sprintf(`direktiv_workflows_success_total{namespace="%s", workflow="%s"}`, mux.Vars(r)["namespace"], mux.Vars(r)["workflow"]), time.Now())
+	if err != nil {
+		ErrResponse(w, err)
+		return
+	}
+
+	writeJSONResponse(w, out)
+}
+
+func (h *Handler) getWorkflowMetrics_Failed(w http.ResponseWriter, r *http.Request) {
+	out, err := h.queryPrometheus(fmt.Sprintf(`direktiv_workflows_failed_total{namespace="%s", workflow="%s"}`, mux.Vars(r)["namespace"], mux.Vars(r)["workflow"]), time.Now())
+	if err != nil {
+		ErrResponse(w, err)
+		return
+	}
+
+	writeJSONResponse(w, out)
+}

--- a/pkg/direktiv/db-instance.go
+++ b/pkg/direktiv/db-instance.go
@@ -135,7 +135,7 @@ func (db *dbManager) addWorkflowInstance(ctx context.Context, ns, workflowID, in
 			errCode = "direktiv.mutex"
 			errMsg = "exclusive property prevents new instances while another exists"
 
-			reportMetricEnd(ns, workflowID, status)
+			reportMetricEnd(ns, workflowID, status, time.Time{})
 		}
 
 	}

--- a/pkg/direktiv/db-instance.go
+++ b/pkg/direktiv/db-instance.go
@@ -134,6 +134,8 @@ func (db *dbManager) addWorkflowInstance(ctx context.Context, ns, workflowID, in
 			status = "failed"
 			errCode = "direktiv.mutex"
 			errMsg = "exclusive property prevents new instances while another exists"
+
+			reportMetricEnd(ns, workflowID, status)
 		}
 
 	}

--- a/pkg/direktiv/engine.go
+++ b/pkg/direktiv/engine.go
@@ -1029,7 +1029,7 @@ func (we *workflowEngine) transitionState(ctx context.Context, wli *workflowLogi
 		wli.Log(ctx, "Workflow failed with error '%s': %s", wli.rec.ErrorCode, wli.rec.ErrorMessage)
 	}
 
-	reportMetricEnd(wli.namespace, wli.wf.ID, status)
+	reportMetricEnd(wli.namespace, wli.wf.ID, status, wli.rec.StateBeginTime)
 
 	wf := wli.rec.Edges.Workflow
 	rec, err = wli.rec.Update().SetOutput(string(data)).SetEndTime(time.Now()).SetStatus(status).Save(ctx)

--- a/pkg/direktiv/engine.go
+++ b/pkg/direktiv/engine.go
@@ -1029,6 +1029,8 @@ func (we *workflowEngine) transitionState(ctx context.Context, wli *workflowLogi
 		wli.Log(ctx, "Workflow failed with error '%s': %s", wli.rec.ErrorCode, wli.rec.ErrorMessage)
 	}
 
+	reportMetricEnd(wli.namespace, wli.wf.ID, status)
+
 	wf := wli.rec.Edges.Workflow
 	rec, err = wli.rec.Update().SetOutput(string(data)).SetEndTime(time.Now()).SetStatus(status).Save(ctx)
 	if err != nil {

--- a/pkg/direktiv/grpc-workflow.go
+++ b/pkg/direktiv/grpc-workflow.go
@@ -113,6 +113,8 @@ func (is *ingressServer) InvokeWorkflow(ctx context.Context, in *ingress.InvokeW
 		return nil, grpcDatabaseError(err, "instance", fmt.Sprintf("%s/%s", namespace, workflow))
 	}
 
+	metricsWfInvoked.WithLabelValues(namespace, workflow, namespace).Inc()
+
 	log.Debugf("Invoked workflow %s/%s: %s", namespace, workflow, inst.id)
 
 	resp.InstanceId = &inst.id

--- a/pkg/direktiv/metrics.go
+++ b/pkg/direktiv/metrics.go
@@ -2,11 +2,73 @@ package direktiv
 
 import (
 	"context"
+	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
 	"github.com/vorteil/direktiv/pkg/metrics"
 
 	"github.com/vorteil/direktiv/pkg/ingress"
 )
+
+var (
+	metricsWfInvoked = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "direktiv",
+			Subsystem: "workflows",
+			Name:      "invoked_total",
+			Help:      "Total number of workflows invoked.",
+		},
+		[]string{"namespace", "workflow", "tenant"},
+	)
+
+	metricsWfSuccess = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "direktiv",
+			Subsystem: "workflows",
+			Name:      "success_total",
+			Help:      "Total number of workflows sucessfully finished.",
+		},
+		[]string{"namespace", "workflow", "tenant"},
+	)
+
+	metricsWfFail = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "direktiv",
+			Subsystem: "workflows",
+			Name:      "failed_total",
+			Help:      "Total number of workflows failed.",
+		},
+		[]string{"namespace", "workflow", "tenant"},
+	)
+)
+
+func reportMetricEnd(namespace, workflow, status string) {
+
+	log.Debugf("reporting workflow %v/%v: %v", namespace, workflow, status)
+	if status == "failed" {
+		metricsWfFail.WithLabelValues(namespace, workflow, namespace).Inc()
+	} else {
+		metricsWfSuccess.WithLabelValues(namespace, workflow, namespace).Inc()
+	}
+
+}
+
+func setupPrometheusEndpoint() {
+
+	log.Infof("starting prometheus endpoint")
+
+	prometheus.MustRegister(metricsWfInvoked)
+	prometheus.MustRegister(metricsWfSuccess)
+	prometheus.MustRegister(metricsWfFail)
+	prometheus.Unregister(prometheus.NewGoCollector())
+	prometheus.Unregister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+
+	http.Handle("/metrics", promhttp.Handler())
+	http.ListenAndServe(":2112", nil)
+
+}
 
 func (is *ingressServer) WorkflowMetrics(ctx context.Context, in *ingress.WorkflowMetricsRequest) (*ingress.WorkflowMetricsResponse, error) {
 

--- a/pkg/direktiv/wfserver.go
+++ b/pkg/direktiv/wfserver.go
@@ -217,6 +217,8 @@ func (s *WorkflowServer) Kill() {
 // Run starts all components of direktiv
 func (s *WorkflowServer) Run() error {
 
+	go setupPrometheusEndpoint()
+
 	log.Debugf("subscribing to sync queue")
 	err := s.startDatabaseListener()
 	if err != nil {

--- a/pkg/direktiv/wli.go
+++ b/pkg/direktiv/wli.go
@@ -249,6 +249,9 @@ func (wli *workflowLogicInstance) Raise(ctx context.Context, cerr *CatchableErro
 			SetErrorCode(cerr.Code).
 			SetErrorMessage(cerr.Message).
 			Save(ctx)
+
+		reportMetricEnd(wli.namespace, wli.wf.ID, "failed")
+
 		wli.rec.Edges.Workflow = wf
 		if err != nil {
 			return NewInternalError(err)
@@ -274,6 +277,7 @@ func (wli *workflowLogicInstance) setStatus(ctx context.Context, status, code, m
 	wf := wli.rec.Edges.Workflow
 
 	if wli.rec.ErrorCode == "" {
+		reportMetricEnd(wli.namespace, wli.wf.ID, status)
 		wli.rec, err = wli.rec.Update().
 			SetStatus(status).
 			SetEndTime(time.Now()).

--- a/pkg/direktiv/wli.go
+++ b/pkg/direktiv/wli.go
@@ -250,7 +250,7 @@ func (wli *workflowLogicInstance) Raise(ctx context.Context, cerr *CatchableErro
 			SetErrorMessage(cerr.Message).
 			Save(ctx)
 
-		reportMetricEnd(wli.namespace, wli.wf.ID, "failed")
+		// reportMetricEnd(wli.namespace, wli.wf.ID, "failed")
 
 		wli.rec.Edges.Workflow = wf
 		if err != nil {
@@ -277,7 +277,7 @@ func (wli *workflowLogicInstance) setStatus(ctx context.Context, status, code, m
 	wf := wli.rec.Edges.Workflow
 
 	if wli.rec.ErrorCode == "" {
-		reportMetricEnd(wli.namespace, wli.wf.ID, status)
+		// reportMetricEnd(wli.namespace, wli.wf.ID, status)
 		wli.rec, err = wli.rec.Update().
 			SetStatus(status).
 			SetEndTime(time.Now()).

--- a/pkg/direktiv/wli.go
+++ b/pkg/direktiv/wli.go
@@ -277,7 +277,7 @@ func (wli *workflowLogicInstance) setStatus(ctx context.Context, status, code, m
 	wf := wli.rec.Edges.Workflow
 
 	if wli.rec.ErrorCode == "" {
-		// reportMetricEnd(wli.namespace, wli.wf.ID, status)
+		reportMetricEnd(wli.namespace, wli.wf.ID, status)
 		wli.rec, err = wli.rec.Update().
 			SetStatus(status).
 			SetEndTime(time.Now()).

--- a/pkg/direktiv/wli.go
+++ b/pkg/direktiv/wli.go
@@ -277,7 +277,7 @@ func (wli *workflowLogicInstance) setStatus(ctx context.Context, status, code, m
 	wf := wli.rec.Edges.Workflow
 
 	if wli.rec.ErrorCode == "" {
-		reportMetricEnd(wli.namespace, wli.wf.ID, status)
+		reportMetricEnd(wli.namespace, wli.wf.ID, status, wli.rec.StateBeginTime)
 		wli.rec, err = wli.rec.Update().
 			SetStatus(status).
 			SetEndTime(time.Now()).


### PR DESCRIPTION
Adds metrics logic to Direktiv.
Prometheus helm charts have been created, and default values enabling the relevant logic to record metrics to prometheus from the Direktiv flow server have been added to the Values.yaml file

Please let me know if you have any feedback or concerns about how this was implemented.

Current metrics being recorded are:

- `direktiv_workflows_total_milliseconds`
- `direktiv_workflows_invoked_total`
- `direktiv_workflows_success_total`
- `direktiv_workflows_failed_total`

APIs have been added to the API server package, allowing for any of the above metrics to be queries on either a namespace or workflow level.