### PR TITLE
Go-swagger docs added for api's

### DIFF
--- a/pkg/api/flow.go
+++ b/pkg/api/flow.go
@@ -50,6 +50,65 @@ func newFlowHandler(logger *zap.SugaredLogger, router *mux.Router, conf *util.Co
 
 }
 
+// swagger:parameters getNamespaces serverLogs namespaceLogs instanceLogs workflowLogs getRegistries getNodes getSecrets getNamespaceVariables getWorkflowVariables getInstanceVariables
+type paginationQueryWrapper struct {
+
+	// in: query
+	After string `json:"after"`
+
+	// in: query
+	First int32 `json:"first"`
+
+	// in: query
+	Before string `json:"before"`
+
+	// in: query
+	Last int32 `json:"last"`
+
+	// PAGE ORDER
+
+	// in: query
+	PageOrderField string `json:"order.field"`
+
+	// in: query
+	PageOrderDirection string `json:"order.direction"`
+
+	// PAGE FILTER
+
+	// in: query
+	PageFilterField string `json:"filter.field"`
+
+	// in: query
+	// description: "Pagination PageFilterDirection"
+	PageFilterType string `json:"filter.type"`
+
+	// in: query
+	// description: "Pagination PageFilterVal"
+	PageFilterVal string `json:"filter.val"`
+}
+
+type paginationBodyWrapper struct {
+
+	// in: query
+	pagination struct {
+		after  string
+		first  int32
+		before string
+		last   int32
+
+		pageOrder struct {
+			field     string
+			direction string
+		}
+
+		pageFilter struct {
+			field string
+			Type  string `json:"type"`
+			val   string
+		}
+	}
+}
+
 func (h *flowHandler) initRoutes(r *mux.Router) {
 
 	// swagger:operation GET /api/namespaces Namespaces getNamespaces
@@ -164,7 +223,24 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	//     "description": "successfully got instance logs"
 	handlerPair(r, RN_GetInstanceLogs, "/namespaces/{ns}/instances/{in}/logs", h.InstanceLogs, h.InstanceLogsSSE)
 
-	// TODO: SWAGGER-SPEC
+	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-invoked Metrics workflowMetricsInvoked
+	// Get metrics of invoked workflow instances
+	// ---
+	// summary: Gets Invoked Workflow Metrics
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: workflow
+	//   type: string
+	//   required: true
+	//   description: 'path to target workflow'
+	// responses:
+	//   '200':
+	//     "description": "successfully got workflow metrics"
 	pathHandler(r, http.MethodGet, RN_GetWorkflowMetrics, "metrics-invoked", h.WorkflowMetricsInvoked)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-successful Metrics workflowMetricsSuccessful
@@ -483,7 +559,7 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	//     "description": "successfully set instance variable"
 	r.HandleFunc("/namespaces/{ns}/instances/{instance}/vars/{var}", h.SetInstanceVariable).Name(RN_SetInstanceVariable).Methods(http.MethodPut)
 
-	// swagger:operation GET /api/namespaces/{namespace}/instances/{instance}/vars Variables getInstanceVariableList
+	// swagger:operation GET /api/namespaces/{namespace}/instances/{instance}/vars Variables getInstanceVariables
 	// Gets a list of variables in a instance
 	// ---
 	// summary: Get List of Instance Variable
@@ -589,7 +665,7 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	//     "description": "successfully set workflow variable"
 	pathHandler(r, http.MethodPut, RN_SetWorkflowVariable, "set-var", h.SetWorkflowVariable)
 
-	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=vars Variables getWorkflowVariableList
+	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=vars Variables getWorkflowVariables
 	// Gets a list of variables in a workflow
 	// ---
 	// summary: Get List of Workflow Variables
@@ -904,38 +980,7 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	//     "description": "successfully updated workflow"
 	pathHandler(r, http.MethodPost, RN_UpdateWorkflow, "update-workflow", h.UpdateWorkflow)
 
-	// swagger:operation PUT /api/namespaces/{namespace}/tree/{workflow}?op=save-workflow Workflows saveWorkflow
-	// Updates a workflow at the target path
-	// ---
-	// summary: Update a Workflow
-	// consumes:
-	// - text/plain
-	// parameters:
-	// - in: path
-	//   name: namespace
-	//   type: string
-	//   required: true
-	//   description: 'target namespace'
-	// - in: path
-	//   name: workflow
-	//   type: string
-	//   required: true
-	//   description: 'path to target workflow'
-	// - in: body
-	//   name: workflow data
-	//   description: Payload that contains both the JSON data to manipulate and jq query.
-	//   schema:
-	//     type: string
-	//     example: |
-	//       description: A simple no-op state that returns Hello world Updated !!!
-	//       states:
-	//       - id: helloworld
-	//         type: noop
-	//         transform:
-	//           result: Hello world Updated !!!
-	// responses:
-	//   '200':
-	//     "description": "successfully update workflow"
+	// TODO: SWAGGER-SPEC
 	pathHandler(r, http.MethodPost, RN_SaveWorkflow, "save-workflow", h.SaveWorkflow)
 	// TODO: SWAGGER-SPEC
 	pathHandler(r, http.MethodPost, RN_DiscardWorkflow, "discard-workflow", h.DiscardWorkflow)
@@ -1073,7 +1118,27 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	//     "description": "successfully executed workflow"
 	pathHandler(r, http.MethodPost, RN_ExecuteWorkflow, "execute", h.ExecuteWorkflow)
 
-	// TODO: SWAGGER-SPEC
+	// swagger:operation GET /api/namespaces/{namespace}/tree/{nodePath} Registries getNodes
+	// Gets Workflow and Directory Nodes at nodePath
+	// ---
+	// summary: Get List of Namespace Nodes
+	// tags:
+	// - "Directory"
+	// - "Workflows"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: nodePath
+	//   type: string
+	//   required: true
+	//   description: 'target path in tree'
+	// responses:
+	//   '200':
+	//     "description": "successfully got namespace nodes"
 	pathHandlerPair(r, RN_GetNode, "", h.GetNode, h.GetNodeSSE)
 
 }

--- a/pkg/api/flow.go
+++ b/pkg/api/flow.go
@@ -50,65 +50,6 @@ func newFlowHandler(logger *zap.SugaredLogger, router *mux.Router, conf *util.Co
 
 }
 
-// swagger:parameters getNamespaces serverLogs namespaceLogs instanceLogs workflowLogs getRegistries getNodes getSecrets getNamespaceVariables getWorkflowVariables getInstanceVariables
-type paginationQueryWrapper struct {
-
-	// in: query
-	After string `json:"after"`
-
-	// in: query
-	First int32 `json:"first"`
-
-	// in: query
-	Before string `json:"before"`
-
-	// in: query
-	Last int32 `json:"last"`
-
-	// PAGE ORDER
-
-	// in: query
-	PageOrderField string `json:"order.field"`
-
-	// in: query
-	PageOrderDirection string `json:"order.direction"`
-
-	// PAGE FILTER
-
-	// in: query
-	PageFilterField string `json:"filter.field"`
-
-	// in: query
-	// description: "Pagination PageFilterDirection"
-	PageFilterType string `json:"filter.type"`
-
-	// in: query
-	// description: "Pagination PageFilterVal"
-	PageFilterVal string `json:"filter.val"`
-}
-
-type paginationBodyWrapper struct {
-
-	// in: query
-	pagination struct {
-		after  string
-		first  int32
-		before string
-		last   int32
-
-		pageOrder struct {
-			field     string
-			direction string
-		}
-
-		pageFilter struct {
-			field string
-			Type  string `json:"type"`
-			val   string
-		}
-	}
-}
-
 func (h *flowHandler) initRoutes(r *mux.Router) {
 
 	// swagger:operation GET /api/namespaces Namespaces getNamespaces
@@ -285,7 +226,7 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-failed Metrics workflowMetricsMilliseconds
 	// Get the timing metrics of a workflow's instance
-	// This returns a total sum of the milliseconds a workflow has been executed for.
+	// This returns a total sum of the milliseconds a workflow has been executed for
 	// ---
 	// summary: Gets Workflow Time Metrics
 	// parameters:
@@ -428,9 +369,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/vars/{var}", h.DeleteNamespaceVariable).Name(RN_SetNamespaceVariable).Methods(http.MethodDelete)
 
 	// swagger:operation PUT /api/namespaces/{namespace}/vars/{variable} Variables setNamespaceVariable
-	// Set the value sorted in a namespace variable.
-	// If the target variable does not exists, it will be created.
-	// Variable data can be anything so long as it can be represented as a string.
+	// Set the value sorted in a namespace variable
+	// If the target variable does not exists, it will be created
+	// Variable data can be anything so long as it can be represented as a string
 	// ---
 	// summary: Set a Namespace Variable
 	// consumes:
@@ -524,9 +465,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/instances/{instance}/vars/{var}", h.DeleteInstanceVariable).Name(RN_SetInstanceVariable).Methods(http.MethodDelete)
 
 	// swagger:operation PUT /api/namespaces/{namespace}/instances/{instance}/vars/{variable} Variables setInstanceVariable
-	// Set the value sorted in a instance variable.
-	// If the target variable does not exists, it will be created.
-	// Variable data can be anything so long as it can be represented as a string.
+	// Set the value sorted in a instance variable
+	// If the target variable does not exists, it will be created
+	// Variable data can be anything so long as it can be represented as a string
 	// ---
 	// summary: Set a Instance Variable
 	// consumes:
@@ -630,9 +571,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodDelete, RN_SetWorkflowVariable, "delete-var", h.DeleteWorkflowVariable)
 
 	// swagger:operation PUT /api/namespaces/{namespace}/tree/{workflow}?op=set-var Variables setWorkflowVariable
-	// Set the value sorted in a workflow variable.
-	// If the target variable does not exists, it will be created.
-	// Variable data can be anything so long as it can be represented as a string.
+	// Set the value sorted in a workflow variable
+	// If the target variable does not exists, it will be created
+	// Variable data can be anything so long as it can be represented as a string
 	// ---
 	// summary: Set a Workflow Variable
 	// consumes:
@@ -947,7 +888,7 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 
 	// swagger:operation POST /api/namespaces/{namespace}/tree/{workflow}?op=update-workflow Workflows updateWorkflow
 	// Updates a workflow at the target path
-	// The body of this request should contain the workflow yaml you want to update to.
+	// The body of this request should contain the workflow yaml you want to update to
 	// ---
 	// summary: Update a Workflow
 	// consumes:
@@ -1018,7 +959,7 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	// swagger:operation POST /api/namespaces/{namespace}/tree/{workflow}?op=set-workflow-event-logging Workflows setWorkflowCloudEventLogs
 	// Set Cloud Event for Workflow to Log to
 	// When configured type `direktiv.instanceLog` cloud events will be generated with the `logger` parameter set to the
-	// conifgured value.
+	// conifgured value
 	// Workflows can be configured to generate cloud events on their namespace
 	// anything the log parameter produces data. Please find more information on this topic below:
 	// https://docs.direktiv.io/docs/examples/logging.html
@@ -1055,7 +996,7 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 
 	// swagger:operation POST /api/namespaces/{namespace}/tree/{workflow}?op=toggle Workflows toggleWorkflow
 	// Toggle's whether or not a workflow is active
-	// Disabled workflows cannot be invoked.
+	// Disabled workflows cannot be invoked
 	// ---
 	// summary: Set Cloud Event for Workflow to Log to
 	// parameters:

--- a/pkg/api/functions.go
+++ b/pkg/api/functions.go
@@ -1,6 +1,7 @@
 // Package classification Direktiv API.
 //
-// direktiv api
+// Direktiv Open API Specification
+// Direktiv Documentation can be found at https://docs.direktiv.io/
 //
 // Terms Of Service:
 //
@@ -268,7 +269,7 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	// Creates a new global scoped knative service revision
 	// Revisions are created with a traffic percentage. This percentage controls
 	// how much traffic will be directed to this revision. Traffic can be set to 100
-	// to direct all traffic.
+	// to direct all traffic
 	// ---
 	// summary: Create Global Service Revision
 	// tags:
@@ -324,7 +325,7 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	// swagger:operation PATCH /api/functions/{serviceName} updateGlobalServiceTraffic
 	// Update Global Service traffic directed to each revision,
 	// traffic can only be configured between two revisions. All other revisions
-	// will bet set to 0 traffic.
+	// will bet set to 0 traffic
 	// ---
 	// summary: Update Global Service Traffic
 	// tags:
@@ -628,7 +629,7 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	// Creates a new namespace scoped knative service revision
 	// Revisions are created with a traffic percentage. This percentage controls
 	// how much traffic will be directed to this revision. Traffic can be set to 100
-	// to direct all traffic.
+	// to direct all traffic
 	// ---
 	// summary: Create Namespace Service Revision
 	// tags:
@@ -689,7 +690,7 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	// swagger:operation PATCH /api/functions/namespaces/{namespace}/function/{serviceName} updateNamespaceServiceTraffic
 	// Update Namespace Service traffic directed to each revision,
 	// traffic can only be configured between two revisions. All other revisions
-	// will bet set to 0 traffic.
+	// will bet set to 0 traffic
 	// ---
 	// summary: Update Namespace Service Traffic
 	// tags:

--- a/pkg/api/functions.go
+++ b/pkg/api/functions.go
@@ -73,28 +73,90 @@ func newFunctionHandler(srv *Server, logger *zap.SugaredLogger,
 
 func (h *functionHandler) initRoutes(r *mux.Router) {
 
-	// swagger:operation GET /api/functions Services getGlobalServiceList
+	// swagger:operation GET /api/functions getGlobalServiceList
 	// Gets a list of global knative services
 	// ---
-	// summary: Get List of Global Service
+	// summary: Get Global Services List
+	// tags:
+	// - "Global Services"
 	// responses:
 	//   '200':
 	//     "description": "successfully got services list"
 	handlerPair(r, RN_ListServices, "", h.listGlobalServices, h.listGlobalServicesSSE)
+
+	// swagger:operation GET /api/functions/{serviceName}/revisions/{revisionGeneration}/pods listGlobalServiceRevisionPods
+	// List a revisions pods of a global scoped knative service
+	// The target revision generation is the number suffix on a revision
+	// Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
+	// ---
+	// summary: Get Global Service Revision Pods List
+	// tags:
+	// - "Global Services"
+	// parameters:
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// - in: path
+	//   name: revisionGeneration
+	//   type: string
+	//   required: true
+	//   description: 'target revision generation'
+	// responses:
+	//   '200':
+	//     "description": "successfully got list of a service revision pods"
 	handlerPair(r, RN_ListPods, "/{svn}/revisions/{rev}/pods", h.listGlobalPods, h.listGlobalPodsSSE)
 
-	// TODO: SWAGGER-SPEC
+	// swagger:operation GET /api/functions/{serviceName} watchGlobalServiceRevisionList
+	// Watch the revision list of a global scoped knative service
+	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+	// ---
+	// summary: Watch Global Service Revision
+	// tags:
+	// - "Global Services"
+	// parameters:
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// produces:
+	//    - "text/event-stream"
+	// responses:
+	//   '200':
+	//     "description": "successfully watching service"
 	r.HandleFunc("/{svn}", h.singleGlobalServiceSSE).Name(RN_WatchServices).Methods(http.MethodGet).Headers("Accept", "text/event-stream")
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation GET /api/functions/{serviceName}/revisions watchGlobalServiceRevisionList
+	// Watch the revision list of a global scoped knative service
+	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+	// ---
+	// summary: Watch Global Service Revision List
+	// tags:
+	// - "Global Services"
+	// parameters:
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// produces:
+	//    - "text/event-stream"
+	// responses:
+	//   '200':
+	//     "description": "successfully watching service revisions"
 	r.HandleFunc("/{svn}/revisions", h.watchGlobalRevisions).Name(RN_WatchRevisions).Methods(http.MethodGet).Headers("Accept", "text/event-stream")
 
-	// swagger:operation GET /api/functions/{serviceName}/revisions/{revisionGeneration} Services watchGlobalRevision
+	// swagger:operation GET /api/functions/{serviceName}/revisions/{revisionGeneration} watchGlobalServiceRevision
 	// Watch a global scoped knative service revision
 	// The target revision generation is the number suffix on a revision
 	// Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
-	// Note: This is a Server-Sent-Event endpoint
+	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
 	// ---
 	// summary: Watch Global Service Revision
+	// tags:
+	// - "Global Services"
 	// parameters:
 	// - in: path
 	//   name: serviceName
@@ -116,13 +178,15 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	// TODO: SWAGGER-SPEC
 	r.HandleFunc("/logs/pod/{pod}", h.watchLogs).Methods(http.MethodGet).Name(RN_WatchLogs)
 
-	// swagger:operation POST /api/functions Services createGlobalService
+	// swagger:operation POST /api/functions createGlobalService
 	// Creates global scoped knative service
 	// Service Names are unique on a scope level
 	// These services can be used as functions in workflows, more about this can be read here:
 	// https://docs.direktiv.io/docs/walkthrough/using-functions.html
 	// ---
 	// summary: Create Global Service
+	// tags:
+	// - "Global Services"
 	// parameters:
 	// - in: body
 	//   name: Service
@@ -166,10 +230,12 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	//     "description": "successfully created service"
 	r.HandleFunc("", h.createGlobalService).Methods(http.MethodPost).Name(RN_CreateService)
 
-	// swagger:operation DELETE /api/functions/{serviceName} Services deleteGlobalService
+	// swagger:operation DELETE /api/functions/{serviceName} deleteGlobalService
 	// Deletes global scoped knative service and all its revisions
 	// ---
 	// summary: Delete Global Service
+	// tags:
+	// - "Global Services"
 	// parameters:
 	// - in: path
 	//   name: serviceName
@@ -181,10 +247,12 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	//     "description": "successfully deleted service"
 	r.HandleFunc("/{svn}", h.deleteGlobalService).Methods(http.MethodDelete).Name(RN_DeleteServices)
 
-	// swagger:operation GET /api/functions/{serviceName} Services getGlobalService
+	// swagger:operation GET /api/functions/{serviceName} getGlobalService
 	// Get details of a global scoped knative service
 	// ---
 	// summary: Get Global Service Details
+	// tags:
+	// - "Global Services"
 	// parameters:
 	// - in: path
 	//   name: serviceName
@@ -196,13 +264,15 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	//     "description": "successfully got service details"
 	r.HandleFunc("/{svn}", h.getGlobalService).Methods(http.MethodGet).Name(RN_GetService)
 
-	// swagger:operation POST /api/functions/{serviceName} Services updateGlobalService
+	// swagger:operation POST /api/functions/{serviceName} updateGlobalService
 	// Creates a new global scoped knative service revision
 	// Revisions are created with a traffic percentage. This percentage controls
 	// how much traffic will be directed to this revision. Traffic can be set to 100
 	// to direct all traffic.
 	// ---
 	// summary: Create Global Service Revision
+	// tags:
+	// - "Global Services"
 	// parameters:
 	// - in: path
 	//   name: serviceName
@@ -251,12 +321,14 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	//     "description": "successfully created service revision"
 	r.HandleFunc("/{svn}", h.updateGlobalService).Methods(http.MethodPost).Name(RN_UpdateService)
 
-	// swagger:operation PATCH /api/functions/{serviceName} Services updateGlobalServiceTraffic
+	// swagger:operation PATCH /api/functions/{serviceName} updateGlobalServiceTraffic
 	// Update Global Service traffic directed to each revision,
 	// traffic can only be configured between two revisions. All other revisions
 	// will bet set to 0 traffic.
 	// ---
 	// summary: Update Global Service Traffic
+	// tags:
+	// - "Global Services"
 	// parameters:
 	// - in: path
 	//   name: serviceName
@@ -296,13 +368,15 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	//     "description": "successfully updated service traffic"
 	r.HandleFunc("/{svn}", h.updateGlobalServiceTraffic).Methods(http.MethodPatch).Name(RN_UpdateServiceTraffic)
 
-	// swagger:operation DELETE /api/functions/{serviceName}/revisions/{revisionGeneration} Services deleteGlobalRevision
+	// swagger:operation DELETE /api/functions/{serviceName}/revisions/{revisionGeneration} deleteGlobalRevision
 	// Delete a global scoped knative service revision
 	// The target revision generation is the number suffix on a revision
 	// Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
 	// Note: Revisions with traffic cannot be deleted
 	// ---
 	// summary: Delete Global Service Revision
+	// tags:
+	// - "Global Services"
 	// parameters:
 	// - in: path
 	//   name: serviceName
@@ -320,41 +394,536 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/{svn}/revisions/{rev}", h.deleteGlobalRevision).Methods(http.MethodDelete).Name(RN_DeleteRevision)
 
 	// namespace
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation GET /api/functions/namespaces/{namespace} getNamespaceServiceList
+	// Gets a list of namespace knative services
+	// ---
+	// summary: Get Namespace Services List
+	// tags:
+	// - "Namespace Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// responses:
+	//   '200':
+	//     "description": "successfully got services list"
 	handlerPair(r, RN_ListNamespaceServices, "/namespaces/{ns}", h.listNamespaceServices, h.listNamespaceServicesSSE)
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}/pods listNamespaceServiceRevisionPods
+	// List a revisions pods of a namespace scoped knative service
+	// The target revision generation is the number suffix on a revision
+	// Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
+	// ---
+	// summary: Get Namespace Service Revision Pods List
+	// tags:
+	// - "Namespace Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// - in: path
+	//   name: revisionGeneration
+	//   type: string
+	//   required: true
+	//   description: 'target revision generation'
+	// responses:
+	//   '200':
+	//     "description": "successfully got list of a service revision pods"
 	handlerPair(r, RN_ListNamespacePods, "/namespaces/{ns}/function/{svn}/revisions/{rev}/pods", h.listNamespacePods, h.listNamespacePodsSSE)
 
-	// TODO: SWAGGER-SPEC
+	// swagger:operation GET /api/functions/namespaces/{namespace}/function/{serviceName} watchNamespaceServiceRevisionList
+	// Watch the revision list of a namespace scoped knative service
+	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+	// ---
+	// summary: Watch Namespace Service Revision
+	// tags:
+	// - "Namespace Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// produces:
+	//    - "text/event-stream"
+	// responses:
+	//   '200':
+	//     "description": "successfully watching service"
 	r.HandleFunc("/namespaces/{ns}/function/{svn}", h.singleNamespaceServiceSSE).Name(RN_WatchServices).Methods(http.MethodGet).Headers("Accept", "text/event-stream")
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions watchNamespaceServiceRevisionList
+	// Watch the revision list of a namespace scoped knative service
+	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+	// ---
+	// summary: Watch Namespace Service Revision List
+	// tags:
+	// - "Namespace Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// produces:
+	//    - "text/event-stream"
+	// responses:
+	//   '200':
+	//     "description": "successfully watching service revisions"
 	r.HandleFunc("/namespaces/{ns}/function/{svn}/revisions", h.watchNamespaceRevisions).Name(RN_WatchRevisions).Methods(http.MethodGet).Headers("Accept", "text/event-stream")
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration} watchNamespaceServiceRevision
+	// Watch a namespace scoped knative service revision
+	// The target revision generation is the number suffix on a revision
+	// Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
+	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+	// ---
+	// summary: Watch Namespace Service Revision
+	// tags:
+	// - "Namespace Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// - in: path
+	//   name: revisionGeneration
+	//   type: string
+	//   required: true
+	//   description: 'target revision generation'
+	// produces:
+	//    - "text/event-stream"
+	// responses:
+	//   '200':
+	//     "description": "successfully watching service revision"
 	r.HandleFunc("/namespaces/{ns}/function/{svn}/revisions/{rev}", h.watchNamespaceRevision).Name(RN_WatchRevisions).Methods(http.MethodGet).Headers("Accept", "text/event-stream")
 
-	// TODO: SWAGGER-SPEC
+	// swagger:operation POST /api/functions/namespaces/{namespace} createNamespaceService
+	// Creates namespace scoped knative service
+	// Service Names are unique on a scope level
+	// These services can be used as functions in workflows, more about this can be read here:
+	// https://docs.direktiv.io/docs/walkthrough/using-functions.html
+	// ---
+	// summary: Create Namespace Service
+	// tags:
+	// - "Namespace Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: body
+	//   name: Service
+	//   description: Payload that contains information on new service
+	//   required: true
+	//   schema:
+	//     type: object
+	//     example:
+	//       name: "fast-request"
+	//       image: "vorteil/request:v12"
+	//       cmd: ""
+	//       minScale: "1"
+	//       size: "small"
+	//     required:
+	//       - name
+	//       - image
+	//       - cmd
+	//       - minScale
+	//       - size
+	//     properties:
+	//       name:
+	//         type: string
+	//         description: Name of new service
+	//       image:
+	//         type: string
+	//         description: Target image a service will use
+	//       cmd:
+	//         type: string
+	//       minScale:
+	//         type: integer
+	//         description: Minimum amount of service pods to be live
+	//       size:
+	//         type: string
+	//         description: Size of created service pods
+	//         enum:
+	//           - small
+	//           - medium
+	//           - large
+	// responses:
+	//   '200':
+	//     "description": "successfully created service"
 	r.HandleFunc("/namespaces/{ns}", h.createNamespaceService).Methods(http.MethodPost).Name(RN_CreateNamespaceService)
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation DELETE /api/functions/namespaces/{namespace}/function/{serviceName} deleteNamespaceService
+	// Deletes namespace scoped knative service and all its revisions
+	// ---
+	// summary: Delete Namespace Service
+	// tags:
+	// - "Namespace Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// responses:
+	//   '200':
+	//     "description": "successfully deleted service"
 	r.HandleFunc("/namespaces/{ns}/function/{svn}", h.deleteNamespaceService).Methods(http.MethodDelete).Name(RN_DeleteNamespaceServices)
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation GET /api/functions/namespaces/{namespace}/function/{serviceName} getNamespaceService
+	// Get details of a namespace scoped knative service
+	// ---
+	// summary: Get Namespace Service Details
+	// tags:
+	// - "Namespace Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// responses:
+	//   '200':
+	//     "description": "successfully got service details"
 	r.HandleFunc("/namespaces/{ns}/function/{svn}", h.getNamespaceService).Methods(http.MethodGet).Name(RN_GetNamespaceService)
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation POST /api/functions/namespaces/{namespace}/function/{serviceName} updateNamespaceService
+	// Creates a new namespace scoped knative service revision
+	// Revisions are created with a traffic percentage. This percentage controls
+	// how much traffic will be directed to this revision. Traffic can be set to 100
+	// to direct all traffic.
+	// ---
+	// summary: Create Namespace Service Revision
+	// tags:
+	// - "Namespace Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// - in: body
+	//   name: Service
+	//   description: Payload that contains information on service revision
+	//   required: true
+	//   schema:
+	//     type: object
+	//     example:
+	//       trafficPercent: 50
+	//       image: "vorteil/request:v10"
+	//       cmd: ""
+	//       minScale: "1"
+	//       size: "small"
+	//     required:
+	//       - image
+	//       - cmd
+	//       - minScale
+	//       - size
+	//       - trafficPercent
+	//     properties:
+	//       trafficPercent:
+	//         type: integer
+	//         description: Traffic percentage new revision will use
+	//       image:
+	//         type: string
+	//         description: Target image a service will use
+	//       cmd:
+	//         type: string
+	//       minScale:
+	//         type: integer
+	//         description: Minimum amount of service pods to be live
+	//       size:
+	//         type: string
+	//         description: Size of created service pods
+	//         enum:
+	//           - small
+	//           - medium
+	//           - large
+	// responses:
+	//   '200':
+	//     "description": "successfully created service revision"
 	r.HandleFunc("/namespaces/{ns}/function/{svn}", h.updateNamespaceService).Methods(http.MethodPost).Name(RN_UpdateNamespaceService)
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation PATCH /api/functions/namespaces/{namespace}/function/{serviceName} updateNamespaceServiceTraffic
+	// Update Namespace Service traffic directed to each revision,
+	// traffic can only be configured between two revisions. All other revisions
+	// will bet set to 0 traffic.
+	// ---
+	// summary: Update Namespace Service Traffic
+	// tags:
+	// - "Namespace Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// - in: body
+	//   name: Service Traffic
+	//   description: Payload that contains information on service traffic
+	//   required: true
+	//   schema:
+	//     type: object
+	//     example:
+	//       values:
+	//         - percent: 60
+	//           revision: namespace-direktiv-fast-request-00002
+	//         - percent: 40
+	//           revision: namespace-direktiv-fast-request-00001
+	//     required:
+	//       - values
+	//     properties:
+	//       values:
+	//         description: List of revision traffic targets
+	//         type: array
+	//         items:
+	//           type: object
+	//           properties:
+	//             percent:
+	//               description: Target traffice percentage
+	//               type: integer
+	//             revision:
+	//               description: Target service revision
+	//               type: string
+	//
+	// responses:
+	//   '200':
+	//     "description": "successfully updated service traffic"
 	r.HandleFunc("/namespaces/{ns}/function/{svn}", h.updateNamespaceServiceTraffic).Methods(http.MethodPatch).Name(RN_UpdateNamespaceServiceTraffic)
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation DELETE /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration} deleteNamespaceRevision
+	// Delete a namespace scoped knative service revision
+	// The target revision generation is the number suffix on a revision
+	// Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
+	// Note: Revisions with traffic cannot be deleted
+	// ---
+	// summary: Delete Namespace Service Revision
+	// tags:
+	// - "Namespace Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: serviceName
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// - in: path
+	//   name: revisionGeneration
+	//   type: string
+	//   required: true
+	//   description: 'target revision generation'
+	// responses:
+	//   '200':
+	//     "description": "successfully deleted service revision"
 	r.HandleFunc("/namespaces/{ns}/function/{svn}/revisions/{rev}", h.deleteNamespaceRevision).Methods(http.MethodDelete).Name(RN_DeleteNamespaceRevision)
 
 	// workflow
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=services listWorkflowServices
+	// Gets a list of workflow knative services
+	// ---
+	// summary: Get Workflow Services List
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: workflow
+	//   type: string
+	//   required: true
+	//   description: 'path to target workflow'
+	// tags:
+	// - "Workflow Services"
+	// responses:
+	//   '200':
+	//     "description": "successfully got services list"
 	pathHandlerPair(r, RN_ListWorkflowServices, "services", h.listWorkflowServices, h.listWorkflowServicesSSE)
+
+	// swagger:operation GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=pods listWorkflowServiceRevisionPods
+	// List a revisions pods of a workflow scoped knative service
+	// The target revision generation (rev query) is the number suffix on a revision
+	// Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'
+	// ---
+	// summary: Get Workflow Service Revision Pods List
+	// tags:
+	// - "Workflow Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: workflow
+	//   type: string
+	//   required: true
+	//   description: 'path to target workflow'
+	// - in: query
+	//   name: svn
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// - in: query
+	//   name: rev
+	//   type: string
+	//   required: true
+	//   description: 'target service revison'
+	// responses:
+	//   '200':
+	//     "description": "successfully got list of a service revision pods"
 	pathHandlerPair(r, RN_ListWorkflowServices, "pods", h.listWorkflowPods, h.listWorkflowPodsSSE)
 
-	// TODO: SWAGGER-SPEC
+	// swagger:operation GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function getWorkflowService
+	// Get a workflow scoped knative service details
+	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+	// ---
+	// summary: Get Workflow Service Details
+	// tags:
+	// - "Workflow Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: workflow
+	//   type: string
+	//   required: true
+	//   description: 'path to target workflow'
+	// - in: query
+	//   name: svn
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// - in: query
+	//   name: version
+	//   type: string
+	//   required: true
+	//   description: 'target service version'
+	// responses:
+	//   '200':
+	//     "description": "successfully got service details"
 	pathHandlerPair(r, RN_ListWorkflowServices, "function", h.singleWorkflowService, h.singleWorkflowServiceSSE)
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revisions getWorkflowServiceRevisionList
+	// Get the revision list of a workflow scoped knative service
+	// ---
+	// summary: Get Workflow Service Revision List
+	// tags:
+	// - "Workflow Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: query
+	//   name: svn
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// - in: query
+	//   name: version
+	//   type: string
+	//   required: true
+	//   description: 'target service version'
+	// - in: path
+	//   name: workflow
+	//   type: string
+	//   required: true
+	//   description: 'path to target workflow'
+	// responses:
+	//   '200':
+	//     "description": "successfully got service revisions"
 	pathHandlerPair(r, RN_ListWorkflowServices, "function-revisions", h.singleWorkflowServiceRevisions, h.singleWorkflowServiceRevisionsSSE)
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revision getWorkflowServiceRevision
+	// Get a workflow scoped knative service revision
+	// This will return details on a single revision
+	// The target revision generation (rev query) is the number suffix on a revision
+	// Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'
+	// ---
+	// summary: Get Workflow Service Revision
+	// tags:
+	// - "Workflow Services"
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: workflow
+	//   type: string
+	//   required: true
+	//   description: 'path to target workflow'
+	// - in: query
+	//   name: svn
+	//   type: string
+	//   required: true
+	//   description: 'target service name'
+	// - in: query
+	//   name: rev
+	//   type: string
+	//   required: true
+	//   description: 'target service revison'
+	// responses:
+	//   '200':
+	//     "description": "successfully got service revision details"
 	pathHandlerPair(r, RN_ListWorkflowServices, "function-revision", h.singleWorkflowServiceRevision, h.singleWorkflowServiceRevisionSSE)
 
 	// TODO: direct control?
@@ -366,11 +935,85 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	// r.HandleFunc("/namespaces/{ns}/function/{svn}/revisions/{rev}", h.deleteNamespaceRevision).Methods(http.MethodDelete).Name(RN_DeleteNamespaceRevision)
 
 	// Registry ..
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation GET /api/namespaces/{namespace}/registries Registries getRegistries
+	// Gets the list of namespace registries
+	// ---
+	// summary: Get List of Namespace Registries
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// responses:
+	//   '200':
+	//     "description": "successfully got namespace registries"
 	r.HandleFunc("/namespaces/{ns}/registries", h.getRegistries).Methods(http.MethodGet).Name(RN_ListRegistries)
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation POST /api/namespaces/{namespace}/registries Registries createRegistry
+	// Create a namespace container registry
+	// This can be used to connect your workflows to private container registries that require tokens
+	// The data property in the body is made up from the registry user and token. It follows the pattern defined below:
+	// data=USER:TOKEN
+	// ---
+	// summary: Create a Namespace Container Registry
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: body
+	//   name: Registry Payload
+	//   description: Payload that contains registry data
+	//   schema:
+	//     type: object
+	//     example:
+	//       data: "admin:8QwFLg%D$qg*"
+	//       reg: "https://prod.customreg.io"
+	//     required:
+	//       - data
+	//       - reg
+	//     properties:
+	//       data:
+	//         type: string
+	//         description: "Target registry connection data containing the user and token."
+	//       reg:
+	//         type: string
+	//         description: Target registry URL
+	// responses:
+	//   '200':
+	//     "description": "successfully created namespace registry"
 	r.HandleFunc("/namespaces/{ns}/registries", h.createRegistry).Methods(http.MethodPost).Name(RN_CreateRegistry)
-	// TODO: SWAGGER-SPEC
+
+	// swagger:operation POST /api/namespaces/{namespace}/registries Registries deleteRegistry
+	// Delete a namespace container registry
+	// ---
+	// summary: Delete a Namespace Container Registry
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: body
+	//   name: Registry Payload
+	//   description: Payload that contains registry data
+	//   schema:
+	//     example:
+	//       data: "admin:8QwFLg%D$qg*"
+	//       reg: "https://prod.customreg.io"
+	//     type: object
+	//     required:
+	//       - reg
+	//     properties:
+	//       reg:
+	//         type: string
+	//         description: Target registry URL
+	// responses:
+	//   '200':
+	//     "description": "successfully delete namespace registry"
 	r.HandleFunc("/namespaces/{ns}/registries", h.deleteRegistry).Methods(http.MethodDelete).Name(RN_DeleteRegistry)
 
 }

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -418,3 +418,64 @@ func sseHeartbeat(w http.ResponseWriter, flusher http.Flusher) error {
 	return nil
 
 }
+
+// Swagger Param Wrappers
+
+// swagger:parameters getNamespaces serverLogs namespaceLogs instanceLogs workflowLogs getRegistries getNodes getSecrets getNamespaceVariables getWorkflowVariables getInstanceVariables
+type paginationQueryWrapper struct {
+
+	// in: query
+	After string `json:"after"`
+
+	// in: query
+	First int32 `json:"first"`
+
+	// in: query
+	Before string `json:"before"`
+
+	// in: query
+	Last int32 `json:"last"`
+
+	// PAGE ORDER
+
+	// in: query
+	PageOrderField string `json:"order.field"`
+
+	// in: query
+	PageOrderDirection string `json:"order.direction"`
+
+	// PAGE FILTER
+
+	// in: query
+	PageFilterField string `json:"filter.field"`
+
+	// in: query
+	// description: "Pagination PageFilterDirection"
+	PageFilterType string `json:"filter.type"`
+
+	// in: query
+	// description: "Pagination PageFilterVal"
+	PageFilterVal string `json:"filter.val"`
+}
+
+type paginationBodyWrapper struct {
+
+	// in: query
+	pagination struct {
+		after  string
+		first  int32
+		before string
+		last   int32
+
+		pageOrder struct {
+			field     string
+			direction string
+		}
+
+		pageFilter struct {
+			field string
+			Type  string `json:"type"`
+			val   string
+		}
+	}
+}

--- a/scripts/api/api.md
+++ b/scripts/api/api.md
@@ -23,7 +23,6 @@ direktiv api
 
 ### Consumes
   * application/json
-  * text/event-stream
   * text/plain
 
 ### Produces
@@ -50,6 +49,24 @@ direktiv api
 | Method  | URI     | Name   | Summary |
 |---------|---------|--------|---------|
 | PUT | /api/namespaces/{namespace}/tree/{directory}?op=create-directory | [create directory](#create-directory) | Create a Directory |
+| GET | /api/namespaces/{namespace}/tree/{nodePath} | [get nodes](#get-nodes) | Get List of Namespace Nodes |
+  
+
+
+###  global_services
+
+| Method  | URI     | Name   | Summary |
+|---------|---------|--------|---------|
+| POST | /api/functions | [create global service](#create-global-service) | Create Global Service |
+| DELETE | /api/functions/{serviceName}/revisions/{revisionGeneration} | [delete global revision](#delete-global-revision) | Delete Global Service Revision |
+| DELETE | /api/functions/{serviceName} | [delete global service](#delete-global-service) | Delete Global Service |
+| GET | /api/functions/{serviceName} | [get global service](#get-global-service) | Get Global Service Details |
+| GET | /api/functions | [get global service list](#get-global-service-list) | Get Global Services List |
+| GET | /api/functions/{serviceName}/revisions/{revisionGeneration}/pods | [list global service revision pods](#list-global-service-revision-pods) | Get Global Service Revision Pods List |
+| POST | /api/functions/{serviceName} | [update global service](#update-global-service) | Create Global Service Revision |
+| PATCH | /api/functions/{serviceName} | [update global service traffic](#update-global-service-traffic) | Update Global Service Traffic |
+| GET | /api/functions/{serviceName}/revisions/{revisionGeneration} | [watch global service revision](#watch-global-service-revision) | Watch Global Service Revision |
+| GET | /api/functions/{serviceName}/revisions | [watch global service revision list](#watch-global-service-revision-list) | Watch Global Service Revision List |
   
 
 
@@ -84,9 +101,27 @@ direktiv api
 | GET | /api/namespaces/{namespace}/metrics/invoked | [namespace metrics invoked](#namespace-metrics-invoked) | Gets Namespace Invoked Workflow Metrics |
 | GET | /api/namespaces/{namespace}/metrics/milliseconds | [namespace metrics milliseconds](#namespace-metrics-milliseconds) | Gets Namespace Workflow Timing Metrics |
 | GET | /api/namespaces/{namespace}/metrics/successful | [namespace metrics successful](#namespace-metrics-successful) | Gets Namespace Successful Workflow Instances Metrics |
+| GET | /api/namespaces/{namespace}/tree/{workflow}?op=metrics-invoked | [workflow metrics invoked](#workflow-metrics-invoked) | Gets Invoked Workflow Metrics |
 | GET | /api/namespaces/{namespace}/tree/{workflow}?op=metrics-failed | [workflow metrics milliseconds](#workflow-metrics-milliseconds) | Gets Workflow Time Metrics |
 | GET | /api/namespaces/{namespace}/tree/{workflow}?op=metrics-state-milliseconds | [workflow metrics state milliseconds](#workflow-metrics-state-milliseconds) | Gets a Workflow State Time Metrics |
 | GET | /api/namespaces/{namespace}/tree/{workflow}?op=metrics-successful | [workflow metrics successful](#workflow-metrics-successful) | Gets Successful Workflow Metrics |
+  
+
+
+###  namespace_services
+
+| Method  | URI     | Name   | Summary |
+|---------|---------|--------|---------|
+| POST | /api/functions/namespaces/{namespace} | [create namespace service](#create-namespace-service) | Create Namespace Service |
+| DELETE | /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration} | [delete namespace revision](#delete-namespace-revision) | Delete Namespace Service Revision |
+| DELETE | /api/functions/namespaces/{namespace}/function/{serviceName} | [delete namespace service](#delete-namespace-service) | Delete Namespace Service |
+| GET | /api/functions/namespaces/{namespace}/function/{serviceName} | [get namespace service](#get-namespace-service) | Get Namespace Service Details |
+| GET | /api/functions/namespaces/{namespace} | [get namespace service list](#get-namespace-service-list) | Get Namespace Services List |
+| GET | /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}/pods | [list namespace service revision pods](#list-namespace-service-revision-pods) | Get Namespace Service Revision Pods List |
+| POST | /api/functions/namespaces/{namespace}/function/{serviceName} | [update namespace service](#update-namespace-service) | Create Namespace Service Revision |
+| PATCH | /api/functions/namespaces/{namespace}/function/{serviceName} | [update namespace service traffic](#update-namespace-service-traffic) | Update Namespace Service Traffic |
+| GET | /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration} | [watch namespace service revision](#watch-namespace-service-revision) | Watch Namespace Service Revision |
+| GET | /api/functions/namespaces/{namespace}/function/{serviceName}/revisions | [watch namespace service revision list](#watch-namespace-service-revision-list) | Watch Namespace Service Revision List |
   
 
 
@@ -109,6 +144,15 @@ direktiv api
   
 
 
+###  registries
+
+| Method  | URI     | Name   | Summary |
+|---------|---------|--------|---------|
+| POST | /api/namespaces/{namespace}/registries | [delete registry](#delete-registry) | Delete a Namespace Container Registry |
+| GET | /api/namespaces/{namespace}/registries | [get registries](#get-registries) | Get List of Namespace Registries |
+  
+
+
 ###  secrets
 
 | Method  | URI     | Name   | Summary |
@@ -116,21 +160,6 @@ direktiv api
 | PUT | /api/namespaces/{namespace}/secrets/{secret} | [create secret](#create-secret) | Create a Namespace Secret |
 | DELETE | /api/namespaces/{namespace}/secrets/{secret} | [delete secret](#delete-secret) | Delete a Namespace Secret |
 | GET | /api/namespaces/{namespace}/secrets | [get secrets](#get-secrets) | Get List of Namespace Secrets |
-  
-
-
-###  services
-
-| Method  | URI     | Name   | Summary |
-|---------|---------|--------|---------|
-| POST | /api/functions | [create global service](#create-global-service) | Create Global Service |
-| DELETE | /api/functions/{serviceName}/revisions/{revisionGeneration} | [delete global revision](#delete-global-revision) | Delete Global Service Revision |
-| DELETE | /api/functions/{serviceName} | [delete global service](#delete-global-service) | Delete Global Service |
-| GET | /api/functions/{serviceName} | [get global service](#get-global-service) | Get Global Service Details |
-| GET | /api/functions | [get global service list](#get-global-service-list) | Get List of Global Service |
-| POST | /api/functions/{serviceName} | [update global service](#update-global-service) | Create Global Service Revision |
-| PATCH | /api/functions/{serviceName} | [update global service traffic](#update-global-service-traffic) | Update Global Service Traffic |
-| GET | /api/functions/{serviceName}/revisions/{revisionGeneration} | [watch global revision](#watch-global-revision) | Watch Global Service Revision |
   
 
 
@@ -146,10 +175,22 @@ direktiv api
 | GET | /api/namespaces/{namespace}/vars/{variable} | [get namespace variable](#get-namespace-variable) | Get a Namespace Variable |
 | GET | /api/namespaces/{namespace}/vars | [get namespace variables](#get-namespace-variables) | Get Namespace Variable List |
 | GET | /api/namespaces/{namespace}/tree/{workflow}?op=var | [get workflow variable](#get-workflow-variable) | Get a Workflow Variable |
-| GET | /api/namespaces/{namespace}/tree/{workflow}?op=vars | [get workflow variable list](#get-workflow-variable-list) | Get List of Workflow Variables |
+| GET | /api/namespaces/{namespace}/tree/{workflow}?op=vars | [get workflow variables](#get-workflow-variables) | Get List of Workflow Variables |
 | PUT | /api/namespaces/{namespace}/instances/{instance}/vars/{variable} | [set instance variable](#set-instance-variable) | Set a Instance Variable |
 | PUT | /api/namespaces/{namespace}/vars/{variable} | [set namespace variable](#set-namespace-variable) | Set a Namespace Variable |
 | PUT | /api/namespaces/{namespace}/tree/{workflow}?op=set-var | [set workflow variable](#set-workflow-variable) | Set a Workflow Variable |
+  
+
+
+###  workflow_services
+
+| Method  | URI     | Name   | Summary |
+|---------|---------|--------|---------|
+| GET | /api/functions/namespaces/{namespace}/tree/{workflow}?op=function | [get workflow service](#get-workflow-service) | Get Workflow Service Details |
+| GET | /api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revision | [get workflow service revision](#get-workflow-service-revision) | Get Workflow Service Revision |
+| GET | /api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revisions | [get workflow service revision list](#get-workflow-service-revision-list) | Get Workflow Service Revision List |
+| GET | /api/functions/namespaces/{namespace}/tree/{workflow}?op=pods | [list workflow service revision pods](#list-workflow-service-revision-pods) | Get Workflow Service Revision Pods List |
+| GET | /api/functions/namespaces/{namespace}/tree/{workflow}?op=services | [list workflow services](#list-workflow-services) | Get Workflow Services List |
   
 
 
@@ -159,7 +200,6 @@ direktiv api
 |---------|---------|--------|---------|
 | PUT | /api/namespaces/{namespace}/tree/{workflow}?op=create-workflow | [create workflow](#create-workflow) | Create a Workflow |
 | POST | /api/namespaces/{namespace}/tree/{workflow}?op=execute | [execute workflow](#execute-workflow) | Execute a Workflow |
-| PUT | /api/namespaces/{namespace}/tree/{workflow}?op=save-workflow | [save workflow](#save-workflow) | Update a Workflow |
 | POST | /api/namespaces/{namespace}/tree/{workflow}?op=set-workflow-event-logging | [set workflow cloud event logs](#set-workflow-cloud-event-logs) | Set Cloud Event for Workflow to Log to |
 | POST | /api/namespaces/{namespace}/tree/{workflow}?op=toggle | [toggle workflow](#toggle-workflow) | Set Cloud Event for Workflow to Log to |
 | POST | /api/namespaces/{namespace}/tree/{workflow}?op=update-workflow | [update workflow](#update-workflow) | Update a Workflow |
@@ -331,6 +371,58 @@ Creates a new namespace
 Status: OK
 
 ###### <span id="create-namespace-200-schema"></span> Schema
+
+### <span id="create-namespace-service"></span> Create Namespace Service (*createNamespaceService*)
+
+```
+POST /api/functions/namespaces/{namespace}
+```
+
+Creates namespace scoped knative service
+Service Names are unique on a scope level
+These services can be used as functions in workflows, more about this can be read here:
+https://docs.direktiv.io/docs/walkthrough/using-functions.html
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| Service | `body` | [CreateNamespaceServiceBody](#create-namespace-service-body) | `CreateNamespaceServiceBody` | | ✓ | | Payload that contains information on new service |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#create-namespace-service-200) | OK | successfully created service |  | [schema](#create-namespace-service-200-schema) |
+
+#### Responses
+
+
+##### <span id="create-namespace-service-200"></span> 200 - successfully created service
+Status: OK
+
+###### <span id="create-namespace-service-200-schema"></span> Schema
+
+###### Inlined models
+
+**<span id="create-namespace-service-body"></span> CreateNamespaceServiceBody**
+
+
+  
+
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| cmd | string| `string` | ✓ | |  |  |
+| image | string| `string` | ✓ | | Target image a service will use |  |
+| minScale | integer| `int64` | ✓ | | Minimum amount of service pods to be live |  |
+| name | string| `string` | ✓ | | Name of new service |  |
+| size | string| `string` | ✓ | | Size of created service pods |  |
+
+
 
 ### <span id="create-secret"></span> Create a Namespace Secret (*createSecret*)
 
@@ -525,6 +617,66 @@ Status: OK
 
 ###### <span id="delete-namespace-200-schema"></span> Schema
 
+### <span id="delete-namespace-revision"></span> Delete Namespace Service Revision (*deleteNamespaceRevision*)
+
+```
+DELETE /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}
+```
+
+Delete a namespace scoped knative service revision
+The target revision generation is the number suffix on a revision
+Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
+Note: Revisions with traffic cannot be deleted
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| revisionGeneration | `path` | string | `string` |  | ✓ |  | target revision generation |
+| serviceName | `path` | string | `string` |  | ✓ |  | target service name |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#delete-namespace-revision-200) | OK | successfully deleted service revision |  | [schema](#delete-namespace-revision-200-schema) |
+
+#### Responses
+
+
+##### <span id="delete-namespace-revision-200"></span> 200 - successfully deleted service revision
+Status: OK
+
+###### <span id="delete-namespace-revision-200-schema"></span> Schema
+
+### <span id="delete-namespace-service"></span> Delete Namespace Service (*deleteNamespaceService*)
+
+```
+DELETE /api/functions/namespaces/{namespace}/function/{serviceName}
+```
+
+Deletes namespace scoped knative service and all its revisions
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| serviceName | `path` | string | `string` |  | ✓ |  | target service name |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#delete-namespace-service-200) | OK | successfully deleted service |  | [schema](#delete-namespace-service-200-schema) |
+
+#### Responses
+
+
+##### <span id="delete-namespace-service-200"></span> 200 - successfully deleted service
+Status: OK
+
+###### <span id="delete-namespace-service-200-schema"></span> Schema
+
 ### <span id="delete-namespace-variable"></span> Delete a Namespace Variable (*deleteNamespaceVariable*)
 
 ```
@@ -552,6 +704,51 @@ Delete a namespace variable
 Status: OK
 
 ###### <span id="delete-namespace-variable-200-schema"></span> Schema
+
+### <span id="delete-registry"></span> Delete a Namespace Container Registry (*deleteRegistry*)
+
+```
+POST /api/namespaces/{namespace}/registries
+```
+
+Delete a namespace container registry
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| Registry Payload | `body` | [DeleteRegistryBody](#delete-registry-body) | `DeleteRegistryBody` | |  | | Payload that contains registry data |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#delete-registry-200) | OK | successfully delete namespace registry |  | [schema](#delete-registry-200-schema) |
+
+#### Responses
+
+
+##### <span id="delete-registry-200"></span> 200 - successfully delete namespace registry
+Status: OK
+
+###### <span id="delete-registry-200-schema"></span> Schema
+
+###### Inlined models
+
+**<span id="delete-registry-body"></span> DeleteRegistryBody**
+
+
+  
+
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| reg | string| `string` | ✓ | | Target registry URL |  |
+
+
 
 ### <span id="delete-secret"></span> Delete a Namespace Secret (*deleteSecret*)
 
@@ -666,7 +863,7 @@ Status: OK
 
 ###### <span id="get-global-service-200-schema"></span> Schema
 
-### <span id="get-global-service-list"></span> Get List of Global Service (*getGlobalServiceList*)
+### <span id="get-global-service-list"></span> Get Global Services List (*getGlobalServiceList*)
 
 ```
 GET /api/functions
@@ -855,6 +1052,61 @@ Status: OK
 
 ###### <span id="get-instance-variable-list-200-schema"></span> Schema
 
+### <span id="get-namespace-service"></span> Get Namespace Service Details (*getNamespaceService*)
+
+```
+GET /api/functions/namespaces/{namespace}/function/{serviceName}
+```
+
+Get details of a namespace scoped knative service
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| serviceName | `path` | string | `string` |  | ✓ |  | target service name |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#get-namespace-service-200) | OK | successfully got service details |  | [schema](#get-namespace-service-200-schema) |
+
+#### Responses
+
+
+##### <span id="get-namespace-service-200"></span> 200 - successfully got service details
+Status: OK
+
+###### <span id="get-namespace-service-200-schema"></span> Schema
+
+### <span id="get-namespace-service-list"></span> Get Namespace Services List (*getNamespaceServiceList*)
+
+```
+GET /api/functions/namespaces/{namespace}
+```
+
+Gets a list of namespace knative services
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#get-namespace-service-list-200) | OK | successfully got services list |  | [schema](#get-namespace-service-list-200-schema) |
+
+#### Responses
+
+
+##### <span id="get-namespace-service-list-200"></span> 200 - successfully got services list
+Status: OK
+
+###### <span id="get-namespace-service-list-200-schema"></span> Schema
+
 ### <span id="get-namespace-variable"></span> Get a Namespace Variable (*getNamespaceVariable*)
 
 ```
@@ -918,6 +1170,20 @@ GET /api/namespaces
 
 Gets the list of namespaces
 
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| after | `query` | string | `string` |  |  |  |  |
+| before | `query` | string | `string` |  |  |  |  |
+| filter.field | `query` | string | `string` |  |  |  |  |
+| filter.type | `query` | string | `string` |  |  |  |  |
+| filter.val | `query` | string | `string` |  |  |  |  |
+| first | `query` | int32 (formatted integer) | `int32` |  |  |  |  |
+| last | `query` | int32 (formatted integer) | `int32` |  |  |  |  |
+| order.direction | `query` | string | `string` |  |  |  |  |
+| order.field | `query` | string | `string` |  |  |  |  |
+
 #### All responses
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
@@ -930,6 +1196,61 @@ Gets the list of namespaces
 Status: OK
 
 ###### <span id="get-namespaces-200-schema"></span> Schema
+
+### <span id="get-nodes"></span> Get List of Namespace Nodes (*getNodes*)
+
+```
+GET /api/namespaces/{namespace}/tree/{nodePath}
+```
+
+Gets Workflow and Directory Nodes at nodePath
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| nodePath | `path` | int32 (formatted string) | `string` |  | ✓ |  | target path in tree |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#get-nodes-200) | OK | successfully got namespace nodes |  | [schema](#get-nodes-200-schema) |
+
+#### Responses
+
+
+##### <span id="get-nodes-200"></span> 200 - successfully got namespace nodes
+Status: OK
+
+###### <span id="get-nodes-200-schema"></span> Schema
+
+### <span id="get-registries"></span> Get List of Namespace Registries (*getRegistries*)
+
+```
+GET /api/namespaces/{namespace}/registries
+```
+
+Gets the list of namespace registries
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#get-registries-200) | OK | successfully got namespace registries |  | [schema](#get-registries-200-schema) |
+
+#### Responses
+
+
+##### <span id="get-registries-200"></span> 200 - successfully got namespace registries
+Status: OK
+
+###### <span id="get-registries-200-schema"></span> Schema
 
 ### <span id="get-secrets"></span> Get List of Namespace Secrets (*getSecrets*)
 
@@ -986,6 +1307,100 @@ Status: OK
 
 ###### <span id="get-workflow-logs-200-schema"></span> Schema
 
+### <span id="get-workflow-service"></span> Get Workflow Service Details (*getWorkflowService*)
+
+```
+GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function
+```
+
+Get a workflow scoped knative service details
+Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
+| svn | `query` | string | `string` |  | ✓ |  | target service name |
+| version | `query` | string | `string` |  | ✓ |  | target service version |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#get-workflow-service-200) | OK | successfully got service details |  | [schema](#get-workflow-service-200-schema) |
+
+#### Responses
+
+
+##### <span id="get-workflow-service-200"></span> 200 - successfully got service details
+Status: OK
+
+###### <span id="get-workflow-service-200-schema"></span> Schema
+
+### <span id="get-workflow-service-revision"></span> Get Workflow Service Revision (*getWorkflowServiceRevision*)
+
+```
+GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revision
+```
+
+Get a workflow scoped knative service revision
+This will return details on a single revision
+The target revision generation (rev query) is the number suffix on a revision
+Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
+| rev | `query` | string | `string` |  | ✓ |  | target service revison |
+| svn | `query` | string | `string` |  | ✓ |  | target service name |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#get-workflow-service-revision-200) | OK | successfully got service revision details |  | [schema](#get-workflow-service-revision-200-schema) |
+
+#### Responses
+
+
+##### <span id="get-workflow-service-revision-200"></span> 200 - successfully got service revision details
+Status: OK
+
+###### <span id="get-workflow-service-revision-200-schema"></span> Schema
+
+### <span id="get-workflow-service-revision-list"></span> Get Workflow Service Revision List (*getWorkflowServiceRevisionList*)
+
+```
+GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revisions
+```
+
+Get the revision list of a workflow scoped knative service
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
+| svn | `query` | string | `string` |  | ✓ |  | target service name |
+| version | `query` | string | `string` |  | ✓ |  | target service version |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#get-workflow-service-revision-list-200) | OK | successfully got service revisions |  | [schema](#get-workflow-service-revision-list-200-schema) |
+
+#### Responses
+
+
+##### <span id="get-workflow-service-revision-list-200"></span> 200 - successfully got service revisions
+Status: OK
+
+###### <span id="get-workflow-service-revision-list-200-schema"></span> Schema
+
 ### <span id="get-workflow-variable"></span> Get a Workflow Variable (*getWorkflowVariable*)
 
 ```
@@ -1015,7 +1430,7 @@ Status: OK
 
 ###### <span id="get-workflow-variable-200-schema"></span> Schema
 
-### <span id="get-workflow-variable-list"></span> Get List of Workflow Variables (*getWorkflowVariableList*)
+### <span id="get-workflow-variables"></span> Get List of Workflow Variables (*getWorkflowVariables*)
 
 ```
 GET /api/namespaces/{namespace}/tree/{workflow}?op=vars
@@ -1028,20 +1443,20 @@ Gets a list of variables in a workflow
 | Name | Source | Type | Go type | Separator | Required | Default | Description |
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
-| workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
+| workflow | `path` | int32 (formatted string) | `string` |  | ✓ |  | path to target workflow |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
-| [200](#get-workflow-variable-list-200) | OK | successfully got workflow variables |  | [schema](#get-workflow-variable-list-200-schema) |
+| [200](#get-workflow-variables-200) | OK | successfully got workflow variables |  | [schema](#get-workflow-variables-200-schema) |
 
 #### Responses
 
 
-##### <span id="get-workflow-variable-list-200"></span> 200 - successfully got workflow variables
+##### <span id="get-workflow-variables-200"></span> 200 - successfully got workflow variables
 Status: OK
 
-###### <span id="get-workflow-variable-list-200-schema"></span> Schema
+###### <span id="get-workflow-variables-200-schema"></span> Schema
 
 ### <span id="instance-logs"></span> Gets Instance Logs (*instanceLogs*)
 
@@ -1055,7 +1470,7 @@ Gets the logs of an executed instance
 
 | Name | Source | Type | Go type | Separator | Required | Default | Description |
 |------|--------|------|---------|-----------| :------: |---------|-------------|
-| instance | `path` | string | `string` |  | ✓ |  | target instance id |
+| instance | `path` | int32 (formatted string) | `string` |  | ✓ |  | target instance id |
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
@@ -1116,6 +1531,127 @@ Status: OK
 | query | string| `string` | ✓ | | jq query to manipulate JSON data |  |
 
 
+
+### <span id="list-global-service-revision-pods"></span> Get Global Service Revision Pods List (*listGlobalServiceRevisionPods*)
+
+```
+GET /api/functions/{serviceName}/revisions/{revisionGeneration}/pods
+```
+
+List a revisions pods of a global scoped knative service
+The target revision generation is the number suffix on a revision
+Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| revisionGeneration | `path` | string | `string` |  | ✓ |  | target revision generation |
+| serviceName | `path` | string | `string` |  | ✓ |  | target service name |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#list-global-service-revision-pods-200) | OK | successfully got list of a service revision pods |  | [schema](#list-global-service-revision-pods-200-schema) |
+
+#### Responses
+
+
+##### <span id="list-global-service-revision-pods-200"></span> 200 - successfully got list of a service revision pods
+Status: OK
+
+###### <span id="list-global-service-revision-pods-200-schema"></span> Schema
+
+### <span id="list-namespace-service-revision-pods"></span> Get Namespace Service Revision Pods List (*listNamespaceServiceRevisionPods*)
+
+```
+GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}/pods
+```
+
+List a revisions pods of a namespace scoped knative service
+The target revision generation is the number suffix on a revision
+Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| revisionGeneration | `path` | string | `string` |  | ✓ |  | target revision generation |
+| serviceName | `path` | string | `string` |  | ✓ |  | target service name |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#list-namespace-service-revision-pods-200) | OK | successfully got list of a service revision pods |  | [schema](#list-namespace-service-revision-pods-200-schema) |
+
+#### Responses
+
+
+##### <span id="list-namespace-service-revision-pods-200"></span> 200 - successfully got list of a service revision pods
+Status: OK
+
+###### <span id="list-namespace-service-revision-pods-200-schema"></span> Schema
+
+### <span id="list-workflow-service-revision-pods"></span> Get Workflow Service Revision Pods List (*listWorkflowServiceRevisionPods*)
+
+```
+GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=pods
+```
+
+List a revisions pods of a workflow scoped knative service
+The target revision generation (rev query) is the number suffix on a revision
+Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
+| rev | `query` | string | `string` |  | ✓ |  | target service revison |
+| svn | `query` | string | `string` |  | ✓ |  | target service name |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#list-workflow-service-revision-pods-200) | OK | successfully got list of a service revision pods |  | [schema](#list-workflow-service-revision-pods-200-schema) |
+
+#### Responses
+
+
+##### <span id="list-workflow-service-revision-pods-200"></span> 200 - successfully got list of a service revision pods
+Status: OK
+
+###### <span id="list-workflow-service-revision-pods-200-schema"></span> Schema
+
+### <span id="list-workflow-services"></span> Get Workflow Services List (*listWorkflowServices*)
+
+```
+GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=services
+```
+
+Gets a list of workflow knative services
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#list-workflow-services-200) | OK | successfully got services list |  | [schema](#list-workflow-services-200-schema) |
+
+#### Responses
+
+
+##### <span id="list-workflow-services-200"></span> 200 - successfully got services list
+Status: OK
+
+###### <span id="list-workflow-services-200-schema"></span> Schema
 
 ### <span id="namespace-logs"></span> Gets Namespace Level Logs (*namespaceLogs*)
 
@@ -1252,38 +1788,6 @@ Status: OK
 
 ###### <span id="namespace-metrics-successful-200-schema"></span> Schema
 
-### <span id="save-workflow"></span> Update a Workflow (*saveWorkflow*)
-
-```
-PUT /api/namespaces/{namespace}/tree/{workflow}?op=save-workflow
-```
-
-Updates a workflow at the target path
-
-#### Consumes
-  * text/plain
-
-#### Parameters
-
-| Name | Source | Type | Go type | Separator | Required | Default | Description |
-|------|--------|------|---------|-----------| :------: |---------|-------------|
-| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
-| workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
-| workflow data | `body` | string | `string` | |  | | Payload that contains both the JSON data to manipulate and jq query. |
-
-#### All responses
-| Code | Status | Description | Has headers | Schema |
-|------|--------|-------------|:-----------:|--------|
-| [200](#save-workflow-200) | OK | successfully update workflow |  | [schema](#save-workflow-200-schema) |
-
-#### Responses
-
-
-##### <span id="save-workflow-200"></span> 200 - successfully update workflow
-Status: OK
-
-###### <span id="save-workflow-200-schema"></span> Schema
-
 ### <span id="server-logs"></span> Get Direktiv Server Logs (*serverLogs*)
 
 ```
@@ -1291,6 +1795,20 @@ GET /api/logs
 ```
 
 Gets Direktiv Server Logs
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| after | `query` | string | `string` |  |  |  |  |
+| before | `query` | string | `string` |  |  |  |  |
+| filter.field | `query` | string | `string` |  |  |  |  |
+| filter.type | `query` | string | `string` |  |  |  |  |
+| filter.val | `query` | string | `string` |  |  |  |  |
+| first | `query` | int32 (formatted integer) | `int32` |  |  |  |  |
+| last | `query` | int32 (formatted integer) | `int32` |  |  |  |  |
+| order.direction | `query` | string | `string` |  |  |  |  |
+| order.field | `query` | string | `string` |  |  |  |  |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -1618,6 +2136,122 @@ Status: OK
 
 
 
+### <span id="update-namespace-service"></span> Create Namespace Service Revision (*updateNamespaceService*)
+
+```
+POST /api/functions/namespaces/{namespace}/function/{serviceName}
+```
+
+Creates a new namespace scoped knative service revision
+Revisions are created with a traffic percentage. This percentage controls
+how much traffic will be directed to this revision. Traffic can be set to 100
+to direct all traffic.
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| serviceName | `path` | string | `string` |  | ✓ |  | target service name |
+| Service | `body` | [UpdateNamespaceServiceBody](#update-namespace-service-body) | `UpdateNamespaceServiceBody` | | ✓ | | Payload that contains information on service revision |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#update-namespace-service-200) | OK | successfully created service revision |  | [schema](#update-namespace-service-200-schema) |
+
+#### Responses
+
+
+##### <span id="update-namespace-service-200"></span> 200 - successfully created service revision
+Status: OK
+
+###### <span id="update-namespace-service-200-schema"></span> Schema
+
+###### Inlined models
+
+**<span id="update-namespace-service-body"></span> UpdateNamespaceServiceBody**
+
+
+  
+
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| cmd | string| `string` | ✓ | |  |  |
+| image | string| `string` | ✓ | | Target image a service will use |  |
+| minScale | integer| `int64` | ✓ | | Minimum amount of service pods to be live |  |
+| size | string| `string` | ✓ | | Size of created service pods |  |
+| trafficPercent | integer| `int64` | ✓ | | Traffic percentage new revision will use |  |
+
+
+
+### <span id="update-namespace-service-traffic"></span> Update Namespace Service Traffic (*updateNamespaceServiceTraffic*)
+
+```
+PATCH /api/functions/namespaces/{namespace}/function/{serviceName}
+```
+
+traffic can only be configured between two revisions. All other revisions
+will bet set to 0 traffic.
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| serviceName | `path` | string | `string` |  | ✓ |  | target service name |
+| Service Traffic | `body` | [UpdateNamespaceServiceTrafficBody](#update-namespace-service-traffic-body) | `UpdateNamespaceServiceTrafficBody` | | ✓ | | Payload that contains information on service traffic |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#update-namespace-service-traffic-200) | OK | successfully updated service traffic |  | [schema](#update-namespace-service-traffic-200-schema) |
+
+#### Responses
+
+
+##### <span id="update-namespace-service-traffic-200"></span> 200 - successfully updated service traffic
+Status: OK
+
+###### <span id="update-namespace-service-traffic-200-schema"></span> Schema
+
+###### Inlined models
+
+**<span id="update-namespace-service-traffic-body"></span> UpdateNamespaceServiceTrafficBody**
+
+
+  
+
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| values | [][UpdateNamespaceServiceTrafficParamsBodyValuesItems0](#update-namespace-service-traffic-params-body-values-items0)| `[]*UpdateNamespaceServiceTrafficParamsBodyValuesItems0` | ✓ | | List of revision traffic targets |  |
+
+
+
+**<span id="update-namespace-service-traffic-params-body-values-items0"></span> UpdateNamespaceServiceTrafficParamsBodyValuesItems0**
+
+
+  
+
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| percent | integer| `int64` |  | | Target traffice percentage |  |
+| revision | string| `string` |  | | Target service revision |  |
+
+
+
 ### <span id="update-workflow"></span> Update a Workflow (*updateWorkflow*)
 
 ```
@@ -1651,7 +2285,7 @@ Status: OK
 
 ###### <span id="update-workflow-200-schema"></span> Schema
 
-### <span id="watch-global-revision"></span> Watch Global Service Revision (*watchGlobalRevision*)
+### <span id="watch-global-service-revision"></span> Watch Global Service Revision (*watchGlobalServiceRevision*)
 
 ```
 GET /api/functions/{serviceName}/revisions/{revisionGeneration}
@@ -1660,10 +2294,7 @@ GET /api/functions/{serviceName}/revisions/{revisionGeneration}
 Watch a global scoped knative service revision
 The target revision generation is the number suffix on a revision
 Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
-Note: This is a Server-Sent-Event endpoint
-
-#### Consumes
-  * text/event-stream
+Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
 
 #### Produces
   * text/event-stream
@@ -1678,15 +2309,141 @@ Note: This is a Server-Sent-Event endpoint
 #### All responses
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
-| [200](#watch-global-revision-200) | OK | successfully watching service revision |  | [schema](#watch-global-revision-200-schema) |
+| [200](#watch-global-service-revision-200) | OK | successfully watching service revision |  | [schema](#watch-global-service-revision-200-schema) |
 
 #### Responses
 
 
-##### <span id="watch-global-revision-200"></span> 200 - successfully watching service revision
+##### <span id="watch-global-service-revision-200"></span> 200 - successfully watching service revision
 Status: OK
 
-###### <span id="watch-global-revision-200-schema"></span> Schema
+###### <span id="watch-global-service-revision-200-schema"></span> Schema
+
+### <span id="watch-global-service-revision-list"></span> Watch Global Service Revision List (*watchGlobalServiceRevisionList*)
+
+```
+GET /api/functions/{serviceName}/revisions
+```
+
+Watch the revision list of a global scoped knative service
+Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+
+#### Produces
+  * text/event-stream
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| serviceName | `path` | string | `string` |  | ✓ |  | target service name |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#watch-global-service-revision-list-200) | OK | successfully watching service revisions |  | [schema](#watch-global-service-revision-list-200-schema) |
+
+#### Responses
+
+
+##### <span id="watch-global-service-revision-list-200"></span> 200 - successfully watching service revisions
+Status: OK
+
+###### <span id="watch-global-service-revision-list-200-schema"></span> Schema
+
+### <span id="watch-namespace-service-revision"></span> Watch Namespace Service Revision (*watchNamespaceServiceRevision*)
+
+```
+GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}
+```
+
+Watch a namespace scoped knative service revision
+The target revision generation is the number suffix on a revision
+Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
+Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+
+#### Produces
+  * text/event-stream
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| revisionGeneration | `path` | string | `string` |  | ✓ |  | target revision generation |
+| serviceName | `path` | string | `string` |  | ✓ |  | target service name |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#watch-namespace-service-revision-200) | OK | successfully watching service revision |  | [schema](#watch-namespace-service-revision-200-schema) |
+
+#### Responses
+
+
+##### <span id="watch-namespace-service-revision-200"></span> 200 - successfully watching service revision
+Status: OK
+
+###### <span id="watch-namespace-service-revision-200-schema"></span> Schema
+
+### <span id="watch-namespace-service-revision-list"></span> Watch Namespace Service Revision List (*watchNamespaceServiceRevisionList*)
+
+```
+GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions
+```
+
+Watch the revision list of a namespace scoped knative service
+Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+
+#### Produces
+  * text/event-stream
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| serviceName | `path` | string | `string` |  | ✓ |  | target service name |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#watch-namespace-service-revision-list-200) | OK | successfully watching service revisions |  | [schema](#watch-namespace-service-revision-list-200-schema) |
+
+#### Responses
+
+
+##### <span id="watch-namespace-service-revision-list-200"></span> 200 - successfully watching service revisions
+Status: OK
+
+###### <span id="watch-namespace-service-revision-list-200-schema"></span> Schema
+
+### <span id="workflow-metrics-invoked"></span> Gets Invoked Workflow Metrics (*workflowMetricsInvoked*)
+
+```
+GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-invoked
+```
+
+Get metrics of invoked workflow instances
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#workflow-metrics-invoked-200) | OK | successfully got workflow metrics |  | [schema](#workflow-metrics-invoked-200-schema) |
+
+#### Responses
+
+
+##### <span id="workflow-metrics-invoked-200"></span> 200 - successfully got workflow metrics
+Status: OK
+
+###### <span id="workflow-metrics-invoked-200-schema"></span> Schema
 
 ### <span id="workflow-metrics-milliseconds"></span> Gets Workflow Time Metrics (*workflowMetricsMilliseconds*)
 

--- a/scripts/api/api.md
+++ b/scripts/api/api.md
@@ -1,16 +1,10 @@
----
-layout: default
-title: API2
-nav_order: 60
-has_children: true
----
 
-# API
 
 
 # Direktiv API.
-direktiv api
-
+Direktiv Open API Specification
+Direktiv Documentation can be found at https://docs.direktiv.io/
+  
 
 ## Informations
 
@@ -20,7 +14,7 @@ direktiv api
 
 ### Contact
 
- info@direktiv.io
+ info@direktiv.io 
 
 ## Content negotiation
 
@@ -56,6 +50,25 @@ direktiv api
 | Method  | URI     | Name   | Summary |
 |---------|---------|--------|---------|
 | PUT | /api/namespaces/{namespace}/tree/{directory}?op=create-directory | [create directory](#create-directory) | Create a Directory |
+| GET | /api/namespaces/{namespace}/tree/{nodePath} | [get nodes](#get-nodes) | Get List of Namespace Nodes |
+  
+
+
+###  global_services
+
+| Method  | URI     | Name   | Summary |
+|---------|---------|--------|---------|
+| POST | /api/functions | [create global service](#create-global-service) | Create Global Service |
+| DELETE | /api/functions/{serviceName}/revisions/{revisionGeneration} | [delete global revision](#delete-global-revision) | Delete Global Service Revision |
+| DELETE | /api/functions/{serviceName} | [delete global service](#delete-global-service) | Delete Global Service |
+| GET | /api/functions/{serviceName} | [get global service](#get-global-service) | Get Global Service Details |
+| GET | /api/functions | [get global service list](#get-global-service-list) | Get Global Services List |
+| GET | /api/functions/{serviceName}/revisions/{revisionGeneration}/pods | [list global service revision pods](#list-global-service-revision-pods) | Get Global Service Revision Pods List |
+| POST | /api/functions/{serviceName} | [update global service](#update-global-service) | Create Global Service Revision |
+| PATCH | /api/functions/{serviceName} | [update global service traffic](#update-global-service-traffic) | Update Global Service Traffic |
+| GET | /api/functions/{serviceName}/revisions/{revisionGeneration} | [watch global service revision](#watch-global-service-revision) | Watch Global Service Revision |
+| GET | /api/functions/{serviceName}/revisions | [watch global service revision list](#watch-global-service-revision-list) | Watch Global Service Revision List |
+  
 
 
 ###  instances
@@ -67,7 +80,7 @@ direktiv api
 | GET | /api/namespaces/{namespace}/instances/{instance}/input | [get instance input](#get-instance-input) | Get a Instance Input |
 | GET | /api/namespaces/{namespace}/instances | [get instance list](#get-instance-list) | Get List Instances |
 | GET | /api/namespaces/{namespace}/instances/{instance}/output | [get instance output](#get-instance-output) | Get a Instance Output |
-
+  
 
 
 ###  logs
@@ -78,7 +91,7 @@ direktiv api
 | GET | /api/namespaces/{namespace}/instances/{instance}/logs | [instance logs](#instance-logs) | Gets Instance Logs |
 | GET | /api/namespaces/{namespace}/logs | [namespace logs](#namespace-logs) | Gets Namespace Level Logs |
 | GET | /api/logs | [server logs](#server-logs) | Get Direktiv Server Logs |
-
+  
 
 
 ###  metrics
@@ -93,7 +106,7 @@ direktiv api
 | GET | /api/namespaces/{namespace}/tree/{workflow}?op=metrics-failed | [workflow metrics milliseconds](#workflow-metrics-milliseconds) | Gets Workflow Time Metrics |
 | GET | /api/namespaces/{namespace}/tree/{workflow}?op=metrics-state-milliseconds | [workflow metrics state milliseconds](#workflow-metrics-state-milliseconds) | Gets a Workflow State Time Metrics |
 | GET | /api/namespaces/{namespace}/tree/{workflow}?op=metrics-successful | [workflow metrics successful](#workflow-metrics-successful) | Gets Successful Workflow Metrics |
-
+  
 
 
 ###  namespace_services
@@ -120,7 +133,7 @@ direktiv api
 | PUT | /api/namespaces/{namespace} | [create namespace](#create-namespace) | Creates a namespace |
 | DELETE | /api/namespaces/{namespace} | [delete namespace](#delete-namespace) | Delete a namespace |
 | GET | /api/namespaces | [get namespaces](#get-namespaces) | Gets the list of namespaces |
-
+  
 
 
 ###  other
@@ -129,32 +142,26 @@ direktiv api
 |---------|---------|--------|---------|
 | POST | /api/namespaces/{namespace}/broadcast | [broadcast cloudevent](#broadcast-cloudevent) | Broadcast Cloud Event |
 | POST | /api/jq | [jq playground](#jq-playground) | JQ Playground api to test jq queries |
-
+  
 
 
 ###  registries
 
 | Method  | URI     | Name   | Summary |
 |---------|---------|--------|---------|
-| PUT | /api/namespaces/{namespace}/secrets/{secret} | [create secret](#create-secret) | Create a Namespace Secret |
-| DELETE | /api/namespaces/{namespace}/secrets/{secret} | [delete secret](#delete-secret) | Delete a Namespace Secret |
-| GET | /api/namespaces/{namespace}/secrets | [get secrets](#get-secrets) | Get List of Namespace Secrets |
-
+| POST | /api/namespaces/{namespace}/registries | [delete registry](#delete-registry) | Delete a Namespace Container Registry |
+| GET | /api/namespaces/{namespace}/registries | [get registries](#get-registries) | Get List of Namespace Registries |
+  
 
 
 ###  secrets
 
 | Method  | URI     | Name   | Summary |
 |---------|---------|--------|---------|
-| POST | /api/functions | [create global service](#create-global-service) | Create Global Service |
-| DELETE | /api/functions/{serviceName}/revisions/{revisionGeneration} | [delete global revision](#delete-global-revision) | Delete Global Service Revision |
-| DELETE | /api/functions/{serviceName} | [delete global service](#delete-global-service) | Delete Global Service |
-| GET | /api/functions/{serviceName} | [get global service](#get-global-service) | Get Global Service Details |
-| GET | /api/functions | [get global service list](#get-global-service-list) | Get List of Global Service |
-| POST | /api/functions/{serviceName} | [update global service](#update-global-service) | Create Global Service Revision |
-| PATCH | /api/functions/{serviceName} | [update global service traffic](#update-global-service-traffic) | Update Global Service Traffic |
-| GET | /api/functions/{serviceName}/revisions/{revisionGeneration} | [watch global revision](#watch-global-revision) | Watch Global Service Revision |
-
+| PUT | /api/namespaces/{namespace}/secrets/{secret} | [create secret](#create-secret) | Create a Namespace Secret |
+| DELETE | /api/namespaces/{namespace}/secrets/{secret} | [delete secret](#delete-secret) | Delete a Namespace Secret |
+| GET | /api/namespaces/{namespace}/secrets | [get secrets](#get-secrets) | Get List of Namespace Secrets |
+  
 
 
 ###  variables
@@ -165,7 +172,7 @@ direktiv api
 | DELETE | /api/namespaces/{namespace}/vars/{variable} | [delete namespace variable](#delete-namespace-variable) | Delete a Namespace Variable |
 | DELETE | /api/namespaces/{namespace}/tree/{workflow}?op=delete-var | [delete workflow variable](#delete-workflow-variable) | Delete a Workflow Variable |
 | GET | /api/namespaces/{namespace}/instances/{instance}/vars/{variable} | [get instance variable](#get-instance-variable) | Get a Instance Variable |
-| GET | /api/namespaces/{namespace}/instances/{instance}/vars | [get instance variable list](#get-instance-variable-list) | Get List of Instance Variable |
+| GET | /api/namespaces/{namespace}/instances/{instance}/vars | [get instance variables](#get-instance-variables) | Get List of Instance Variable |
 | GET | /api/namespaces/{namespace}/vars/{variable} | [get namespace variable](#get-namespace-variable) | Get a Namespace Variable |
 | GET | /api/namespaces/{namespace}/vars | [get namespace variables](#get-namespace-variables) | Get Namespace Variable List |
 | GET | /api/namespaces/{namespace}/tree/{workflow}?op=var | [get workflow variable](#get-workflow-variable) | Get a Workflow Variable |
@@ -173,7 +180,7 @@ direktiv api
 | PUT | /api/namespaces/{namespace}/instances/{instance}/vars/{variable} | [set instance variable](#set-instance-variable) | Set a Instance Variable |
 | PUT | /api/namespaces/{namespace}/vars/{variable} | [set namespace variable](#set-namespace-variable) | Set a Namespace Variable |
 | PUT | /api/namespaces/{namespace}/tree/{workflow}?op=set-var | [set workflow variable](#set-workflow-variable) | Set a Workflow Variable |
-
+  
 
 
 ###  workflow_services
@@ -197,7 +204,7 @@ direktiv api
 | POST | /api/namespaces/{namespace}/tree/{workflow}?op=set-workflow-event-logging | [set workflow cloud event logs](#set-workflow-cloud-event-logs) | Set Cloud Event for Workflow to Log to |
 | POST | /api/namespaces/{namespace}/tree/{workflow}?op=toggle | [toggle workflow](#toggle-workflow) | Set Cloud Event for Workflow to Log to |
 | POST | /api/namespaces/{namespace}/tree/{workflow}?op=update-workflow | [update workflow](#update-workflow) | Update a Workflow |
-
+  
 
 
 ## Paths
@@ -323,7 +330,7 @@ Status: OK
 **<span id="create-global-service-body"></span> CreateGlobalServiceBody**
 
 
-
+  
 
 
 
@@ -452,7 +459,7 @@ Status: OK
 **<span id="create-secret-body"></span> CreateSecretBody**
 
 
-
+  
 
 
 
@@ -1018,7 +1025,7 @@ Status: OK
 
 ###### <span id="get-instance-variable-200-schema"></span> Schema
 
-### <span id="get-instance-variable-list"></span> Get List of Instance Variable (*getInstanceVariableList*)
+### <span id="get-instance-variables"></span> Get List of Instance Variable (*getInstanceVariables*)
 
 ```
 GET /api/namespaces/{namespace}/instances/{instance}/vars
@@ -1030,21 +1037,21 @@ Gets a list of variables in a instance
 
 | Name | Source | Type | Go type | Separator | Required | Default | Description |
 |------|--------|------|---------|-----------| :------: |---------|-------------|
-| instance | `path` | string | `string` |  | ✓ |  | target instance |
+| instance | `path` | int32 (formatted string) | `string` |  | ✓ |  | target instance |
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
-| [200](#get-instance-variable-list-200) | OK | successfully got instance variables |  | [schema](#get-instance-variable-list-200-schema) |
+| [200](#get-instance-variables-200) | OK | successfully got instance variables |  | [schema](#get-instance-variables-200-schema) |
 
 #### Responses
 
 
-##### <span id="get-instance-variable-list-200"></span> 200 - successfully got instance variables
+##### <span id="get-instance-variables-200"></span> 200 - successfully got instance variables
 Status: OK
 
-###### <span id="get-instance-variable-list-200-schema"></span> Schema
+###### <span id="get-instance-variables-200-schema"></span> Schema
 
 ### <span id="get-namespace-service"></span> Get Namespace Service Details (*getNamespaceService*)
 
@@ -1513,7 +1520,7 @@ Status: OK
 **<span id="jq-playground-body"></span> JqPlaygroundBody**
 
 
-
+  
 
 
 
@@ -1823,8 +1830,9 @@ Status: OK
 PUT /api/namespaces/{namespace}/instances/{instance}/vars/{variable}
 ```
 
-If the target variable does not exists, it will be created.
-Variable data can be anything so long as it can be represented as a string.
+Set the value sorted in a instance variable
+If the target variable does not exists, it will be created
+Variable data can be anything so long as it can be represented as a string
 
 #### Consumes
   * text/plain
@@ -1857,8 +1865,9 @@ Status: OK
 PUT /api/namespaces/{namespace}/vars/{variable}
 ```
 
-If the target variable does not exists, it will be created.
-Variable data can be anything so long as it can be represented as a string.
+Set the value sorted in a namespace variable
+If the target variable does not exists, it will be created
+Variable data can be anything so long as it can be represented as a string
 
 #### Consumes
   * text/plain
@@ -1892,7 +1901,7 @@ POST /api/namespaces/{namespace}/tree/{workflow}?op=set-workflow-event-logging
 
 Set Cloud Event for Workflow to Log to
 When configured type `direktiv.instanceLog` cloud events will be generated with the `logger` parameter set to the
-conifgured value.
+conifgured value
 Workflows can be configured to generate cloud events on their namespace
 anything the log parameter produces data. Please find more information on this topic below:
 https://docs.direktiv.io/docs/examples/logging.html
@@ -1923,7 +1932,7 @@ Status: OK
 **<span id="set-workflow-cloud-event-logs-body"></span> SetWorkflowCloudEventLogsBody**
 
 
-
+  
 
 
 
@@ -1941,8 +1950,9 @@ Status: OK
 PUT /api/namespaces/{namespace}/tree/{workflow}?op=set-var
 ```
 
-If the target variable does not exists, it will be created.
-Variable data can be anything so long as it can be represented as a string.
+Set the value sorted in a workflow variable
+If the target variable does not exists, it will be created
+Variable data can be anything so long as it can be represented as a string
 
 #### Consumes
   * text/plain
@@ -1976,7 +1986,7 @@ POST /api/namespaces/{namespace}/tree/{workflow}?op=toggle
 ```
 
 Toggle's whether or not a workflow is active
-Disabled workflows cannot be invoked.
+Disabled workflows cannot be invoked
 
 #### Parameters
 
@@ -2004,7 +2014,7 @@ Status: OK
 **<span id="toggle-workflow-body"></span> ToggleWorkflowBody**
 
 
-
+  
 
 
 
@@ -2025,7 +2035,7 @@ POST /api/functions/{serviceName}
 Creates a new global scoped knative service revision
 Revisions are created with a traffic percentage. This percentage controls
 how much traffic will be directed to this revision. Traffic can be set to 100
-to direct all traffic.
+to direct all traffic
 
 #### Parameters
 
@@ -2052,7 +2062,7 @@ Status: OK
 **<span id="update-global-service-body"></span> UpdateGlobalServiceBody**
 
 
-
+  
 
 
 
@@ -2075,7 +2085,7 @@ PATCH /api/functions/{serviceName}
 ```
 
 traffic can only be configured between two revisions. All other revisions
-will bet set to 0 traffic.
+will bet set to 0 traffic
 
 #### Parameters
 
@@ -2102,7 +2112,7 @@ Status: OK
 **<span id="update-global-service-traffic-body"></span> UpdateGlobalServiceTrafficBody**
 
 
-
+  
 
 
 
@@ -2117,7 +2127,7 @@ Status: OK
 **<span id="update-global-service-traffic-params-body-values-items0"></span> UpdateGlobalServiceTrafficParamsBodyValuesItems0**
 
 
-
+  
 
 
 
@@ -2139,7 +2149,7 @@ POST /api/functions/namespaces/{namespace}/function/{serviceName}
 Creates a new namespace scoped knative service revision
 Revisions are created with a traffic percentage. This percentage controls
 how much traffic will be directed to this revision. Traffic can be set to 100
-to direct all traffic.
+to direct all traffic
 
 #### Parameters
 
@@ -2190,7 +2200,7 @@ PATCH /api/functions/namespaces/{namespace}/function/{serviceName}
 ```
 
 traffic can only be configured between two revisions. All other revisions
-will bet set to 0 traffic.
+will bet set to 0 traffic
 
 #### Parameters
 
@@ -2253,7 +2263,7 @@ POST /api/namespaces/{namespace}/tree/{workflow}?op=update-workflow
 ```
 
 Updates a workflow at the target path
-The body of this request should contain the workflow yaml you want to update to.
+The body of this request should contain the workflow yaml you want to update to
 
 #### Consumes
   * text/plain
@@ -2288,6 +2298,38 @@ GET /api/functions/{serviceName}/revisions/{revisionGeneration}
 Watch a global scoped knative service revision
 The target revision generation is the number suffix on a revision
 Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
+Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+
+#### Produces
+  * text/event-stream
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| revisionGeneration | `path` | string | `string` |  | ✓ |  | target revision generation |
+| serviceName | `path` | string | `string` |  | ✓ |  | target service name |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#watch-global-service-revision-200) | OK | successfully watching service revision |  | [schema](#watch-global-service-revision-200-schema) |
+
+#### Responses
+
+
+##### <span id="watch-global-service-revision-200"></span> 200 - successfully watching service revision
+Status: OK
+
+###### <span id="watch-global-service-revision-200-schema"></span> Schema
+
+### <span id="watch-global-service-revision-list"></span> Watch Global Service Revision List (*watchGlobalServiceRevisionList*)
+
+```
+GET /api/functions/{serviceName}/revisions
+```
+
+Watch the revision list of a global scoped knative service
 Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
 
 #### Produces
@@ -2414,7 +2456,7 @@ GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-failed
 ```
 
 Get the timing metrics of a workflow's instance
-This returns a total sum of the milliseconds a workflow has been executed for.
+This returns a total sum of the milliseconds a workflow has been executed for
 
 #### Parameters
 

--- a/scripts/api/swagger.json
+++ b/scripts/api/swagger.json
@@ -24,9 +24,9 @@
       "get": {
         "description": "Gets a list of global knative services",
         "tags": [
-          "Services"
+          "Global Services"
         ],
-        "summary": "Get List of Global Service",
+        "summary": "Get Global Services List",
         "operationId": "getGlobalServiceList",
         "responses": {
           "200": {
@@ -37,7 +37,7 @@
       "post": {
         "description": "Creates global scoped knative service\nService Names are unique on a scope level\nThese services can be used as functions in workflows, more about this can be read here:\nhttps://docs.direktiv.io/docs/walkthrough/using-functions.html",
         "tags": [
-          "Services"
+          "Global Services"
         ],
         "summary": "Create Global Service",
         "operationId": "createGlobalService",
@@ -99,11 +99,676 @@
         }
       }
     },
+    "/api/functions/namespaces/{namespace}": {
+      "get": {
+        "description": "Gets a list of namespace knative services",
+        "tags": [
+          "Namespace Services"
+        ],
+        "summary": "Get Namespace Services List",
+        "operationId": "getNamespaceServiceList",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got services list"
+          }
+        }
+      },
+      "post": {
+        "description": "Creates namespace scoped knative service\nService Names are unique on a scope level\nThese services can be used as functions in workflows, more about this can be read here:\nhttps://docs.direktiv.io/docs/walkthrough/using-functions.html",
+        "tags": [
+          "Namespace Services"
+        ],
+        "summary": "Create Namespace Service",
+        "operationId": "createNamespaceService",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Payload that contains information on new service",
+            "name": "Service",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "name",
+                "image",
+                "cmd",
+                "minScale",
+                "size"
+              ],
+              "properties": {
+                "cmd": {
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Target image a service will use",
+                  "type": "string"
+                },
+                "minScale": {
+                  "description": "Minimum amount of service pods to be live",
+                  "type": "integer"
+                },
+                "name": {
+                  "description": "Name of new service",
+                  "type": "string"
+                },
+                "size": {
+                  "description": "Size of created service pods",
+                  "type": "string",
+                  "enum": [
+                    "small",
+                    "medium",
+                    "large"
+                  ]
+                }
+              },
+              "example": {
+                "cmd": "",
+                "image": "vorteil/request:v12",
+                "minScale": "1",
+                "name": "fast-request",
+                "size": "small"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully created service"
+          }
+        }
+      }
+    },
+    "/api/functions/namespaces/{namespace}/function/{serviceName}": {
+      "get": {
+        "description": "Get details of a namespace scoped knative service",
+        "tags": [
+          "Namespace Services"
+        ],
+        "summary": "Get Namespace Service Details",
+        "operationId": "getNamespaceService",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "serviceName",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got service details"
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new namespace scoped knative service revision\nRevisions are created with a traffic percentage. This percentage controls\nhow much traffic will be directed to this revision. Traffic can be set to 100\nto direct all traffic.",
+        "tags": [
+          "Namespace Services"
+        ],
+        "summary": "Create Namespace Service Revision",
+        "operationId": "updateNamespaceService",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "serviceName",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Payload that contains information on service revision",
+            "name": "Service",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "image",
+                "cmd",
+                "minScale",
+                "size",
+                "trafficPercent"
+              ],
+              "properties": {
+                "cmd": {
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Target image a service will use",
+                  "type": "string"
+                },
+                "minScale": {
+                  "description": "Minimum amount of service pods to be live",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size of created service pods",
+                  "type": "string",
+                  "enum": [
+                    "small",
+                    "medium",
+                    "large"
+                  ]
+                },
+                "trafficPercent": {
+                  "description": "Traffic percentage new revision will use",
+                  "type": "integer"
+                }
+              },
+              "example": {
+                "cmd": "",
+                "image": "vorteil/request:v10",
+                "minScale": "1",
+                "size": "small",
+                "trafficPercent": 50
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully created service revision"
+          }
+        }
+      },
+      "delete": {
+        "description": "Deletes namespace scoped knative service and all its revisions",
+        "tags": [
+          "Namespace Services"
+        ],
+        "summary": "Delete Namespace Service",
+        "operationId": "deleteNamespaceService",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "serviceName",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully deleted service"
+          }
+        }
+      },
+      "patch": {
+        "description": "traffic can only be configured between two revisions. All other revisions\nwill bet set to 0 traffic.",
+        "tags": [
+          "Namespace Services"
+        ],
+        "summary": "Update Namespace Service Traffic",
+        "operationId": "updateNamespaceServiceTraffic",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "serviceName",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Payload that contains information on service traffic",
+            "name": "Service Traffic",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "values"
+              ],
+              "properties": {
+                "values": {
+                  "description": "List of revision traffic targets",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "percent": {
+                        "description": "Target traffice percentage",
+                        "type": "integer"
+                      },
+                      "revision": {
+                        "description": "Target service revision",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "example": {
+                "values": [
+                  {
+                    "percent": 60,
+                    "revision": "namespace-direktiv-fast-request-00002"
+                  },
+                  {
+                    "percent": 40,
+                    "revision": "namespace-direktiv-fast-request-00001"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully updated service traffic"
+          }
+        }
+      }
+    },
+    "/api/functions/namespaces/{namespace}/function/{serviceName}/revisions": {
+      "get": {
+        "description": "Watch the revision list of a namespace scoped knative service\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
+        "produces": [
+          "text/event-stream"
+        ],
+        "tags": [
+          "Namespace Services"
+        ],
+        "summary": "Watch Namespace Service Revision List",
+        "operationId": "watchNamespaceServiceRevisionList",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "serviceName",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully watching service revisions"
+          }
+        }
+      }
+    },
+    "/api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}": {
+      "get": {
+        "description": "Watch a namespace scoped knative service revision\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
+        "produces": [
+          "text/event-stream"
+        ],
+        "tags": [
+          "Namespace Services"
+        ],
+        "summary": "Watch Namespace Service Revision",
+        "operationId": "watchNamespaceServiceRevision",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "serviceName",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target revision generation",
+            "name": "revisionGeneration",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully watching service revision"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a namespace scoped knative service revision\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'\nNote: Revisions with traffic cannot be deleted",
+        "tags": [
+          "Namespace Services"
+        ],
+        "summary": "Delete Namespace Service Revision",
+        "operationId": "deleteNamespaceRevision",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "serviceName",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target revision generation",
+            "name": "revisionGeneration",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully deleted service revision"
+          }
+        }
+      }
+    },
+    "/api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}/pods": {
+      "get": {
+        "description": "List a revisions pods of a namespace scoped knative service\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'",
+        "tags": [
+          "Namespace Services"
+        ],
+        "summary": "Get Namespace Service Revision Pods List",
+        "operationId": "listNamespaceServiceRevisionPods",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "serviceName",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target revision generation",
+            "name": "revisionGeneration",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got list of a service revision pods"
+          }
+        }
+      }
+    },
+    "/api/functions/namespaces/{namespace}/tree/{workflow}?op=function": {
+      "get": {
+        "description": "Get a workflow scoped knative service details\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
+        "tags": [
+          "Workflow Services"
+        ],
+        "summary": "Get Workflow Service Details",
+        "operationId": "getWorkflowService",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "path to target workflow",
+            "name": "workflow",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "svn",
+            "in": "query",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service version",
+            "name": "version",
+            "in": "query",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got service details"
+          }
+        }
+      }
+    },
+    "/api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revision": {
+      "get": {
+        "description": "Get a workflow scoped knative service revision\nThis will return details on a single revision\nThe target revision generation (rev query) is the number suffix on a revision\nExample: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'",
+        "tags": [
+          "Workflow Services"
+        ],
+        "summary": "Get Workflow Service Revision",
+        "operationId": "getWorkflowServiceRevision",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "path to target workflow",
+            "name": "workflow",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "svn",
+            "in": "query",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service revison",
+            "name": "rev",
+            "in": "query",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got service revision details"
+          }
+        }
+      }
+    },
+    "/api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revisions": {
+      "get": {
+        "description": "Get the revision list of a workflow scoped knative service",
+        "tags": [
+          "Workflow Services"
+        ],
+        "summary": "Get Workflow Service Revision List",
+        "operationId": "getWorkflowServiceRevisionList",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "svn",
+            "in": "query",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service version",
+            "name": "version",
+            "in": "query",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "path to target workflow",
+            "name": "workflow",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got service revisions"
+          }
+        }
+      }
+    },
+    "/api/functions/namespaces/{namespace}/tree/{workflow}?op=pods": {
+      "get": {
+        "description": "List a revisions pods of a workflow scoped knative service\nThe target revision generation (rev query) is the number suffix on a revision\nExample: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'",
+        "tags": [
+          "Workflow Services"
+        ],
+        "summary": "Get Workflow Service Revision Pods List",
+        "operationId": "listWorkflowServiceRevisionPods",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "path to target workflow",
+            "name": "workflow",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "svn",
+            "in": "query",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target service revison",
+            "name": "rev",
+            "in": "query",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got list of a service revision pods"
+          }
+        }
+      }
+    },
+    "/api/functions/namespaces/{namespace}/tree/{workflow}?op=services": {
+      "get": {
+        "description": "Gets a list of workflow knative services",
+        "tags": [
+          "Workflow Services"
+        ],
+        "summary": "Get Workflow Services List",
+        "operationId": "listWorkflowServices",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "path to target workflow",
+            "name": "workflow",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got services list"
+          }
+        }
+      }
+    },
     "/api/functions/{serviceName}": {
       "get": {
         "description": "Get details of a global scoped knative service",
         "tags": [
-          "Services"
+          "Global Services"
         ],
         "summary": "Get Global Service Details",
         "operationId": "getGlobalService",
@@ -125,7 +790,7 @@
       "post": {
         "description": "Creates a new global scoped knative service revision\nRevisions are created with a traffic percentage. This percentage controls\nhow much traffic will be directed to this revision. Traffic can be set to 100\nto direct all traffic.",
         "tags": [
-          "Services"
+          "Global Services"
         ],
         "summary": "Create Global Service Revision",
         "operationId": "updateGlobalService",
@@ -196,7 +861,7 @@
       "delete": {
         "description": "Deletes global scoped knative service and all its revisions",
         "tags": [
-          "Services"
+          "Global Services"
         ],
         "summary": "Delete Global Service",
         "operationId": "deleteGlobalService",
@@ -218,7 +883,7 @@
       "patch": {
         "description": "traffic can only be configured between two revisions. All other revisions\nwill bet set to 0 traffic.",
         "tags": [
-          "Services"
+          "Global Services"
         ],
         "summary": "Update Global Service Traffic",
         "operationId": "updateGlobalServiceTraffic",
@@ -281,20 +946,44 @@
         }
       }
     },
-    "/api/functions/{serviceName}/revisions/{revisionGeneration}": {
+    "/api/functions/{serviceName}/revisions": {
       "get": {
-        "description": "Watch a global scoped knative service revision\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'\nNote: This is a Server-Sent-Event endpoint",
-        "consumes": [
-          "text/event-stream"
-        ],
+        "description": "Watch the revision list of a global scoped knative service\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
         "produces": [
           "text/event-stream"
         ],
         "tags": [
-          "Services"
+          "Global Services"
+        ],
+        "summary": "Watch Global Service Revision List",
+        "operationId": "watchGlobalServiceRevisionList",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "serviceName",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully watching service revisions"
+          }
+        }
+      }
+    },
+    "/api/functions/{serviceName}/revisions/{revisionGeneration}": {
+      "get": {
+        "description": "Watch a global scoped knative service revision\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
+        "produces": [
+          "text/event-stream"
+        ],
+        "tags": [
+          "Global Services"
         ],
         "summary": "Watch Global Service Revision",
-        "operationId": "watchGlobalRevision",
+        "operationId": "watchGlobalServiceRevision",
         "parameters": [
           {
             "type": "string",
@@ -320,7 +1009,7 @@
       "delete": {
         "description": "Delete a global scoped knative service revision\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'\nNote: Revisions with traffic cannot be deleted",
         "tags": [
-          "Services"
+          "Global Services"
         ],
         "summary": "Delete Global Service Revision",
         "operationId": "deleteGlobalRevision",
@@ -343,6 +1032,37 @@
         "responses": {
           "200": {
             "description": "successfully deleted service revision"
+          }
+        }
+      }
+    },
+    "/api/functions/{serviceName}/revisions/{revisionGeneration}/pods": {
+      "get": {
+        "description": "List a revisions pods of a global scoped knative service\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'",
+        "tags": [
+          "Global Services"
+        ],
+        "summary": "Get Global Service Revision Pods List",
+        "operationId": "listGlobalServiceRevisionPods",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "serviceName",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target revision generation",
+            "name": "revisionGeneration",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got list of a service revision pods"
           }
         }
       }
@@ -398,6 +1118,64 @@
         ],
         "summary": "Get Direktiv Server Logs",
         "operationId": "serverLogs",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "After",
+            "name": "after",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "x-go-name": "First",
+            "name": "first",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Before",
+            "name": "before",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "x-go-name": "Last",
+            "name": "last",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PageOrderField",
+            "name": "order.field",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PageOrderDirection",
+            "name": "order.direction",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PageFilterField",
+            "name": "filter.field",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PageFilterType",
+            "name": "filter.type",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PageFilterVal",
+            "name": "filter.val",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "successfully got server logs"
@@ -413,6 +1191,64 @@
         ],
         "summary": "Gets the list of namespaces",
         "operationId": "getNamespaces",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "After",
+            "name": "after",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "x-go-name": "First",
+            "name": "first",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Before",
+            "name": "before",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "x-go-name": "Last",
+            "name": "last",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PageOrderField",
+            "name": "order.field",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PageOrderDirection",
+            "name": "order.direction",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PageFilterField",
+            "name": "filter.field",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PageFilterType",
+            "name": "filter.type",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PageFilterVal",
+            "name": "filter.val",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "successfully got list of namespaces"
@@ -626,6 +1462,7 @@
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "After",
             "description": "target namespace",
             "name": "namespace",
             "in": "path",
@@ -633,6 +1470,8 @@
           },
           {
             "type": "string",
+            "format": "int32",
+            "x-go-name": "First",
             "description": "target instance id",
             "name": "instance",
             "in": "path",
@@ -843,6 +1682,7 @@
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "After",
             "description": "target namespace",
             "name": "namespace",
             "in": "path",
@@ -952,6 +1792,74 @@
         }
       }
     },
+    "/api/namespaces/{namespace}/registries": {
+      "get": {
+        "description": "Gets the list of namespace registries",
+        "tags": [
+          "Registries"
+        ],
+        "summary": "Get List of Namespace Registries",
+        "operationId": "getRegistries",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "After",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got namespace registries"
+          }
+        }
+      },
+      "post": {
+        "description": "Delete a namespace container registry",
+        "tags": [
+          "Registries"
+        ],
+        "summary": "Delete a Namespace Container Registry",
+        "operationId": "deleteRegistry",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Payload that contains registry data",
+            "name": "Registry Payload",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "required": [
+                "reg"
+              ],
+              "properties": {
+                "reg": {
+                  "description": "Target registry URL",
+                  "type": "string"
+                }
+              },
+              "example": {
+                "data": "admin:8QwFLg%D$qg*",
+                "reg": "https://prod.customreg.io"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully delete namespace registry"
+          }
+        }
+      }
+    },
     "/api/namespaces/{namespace}/secrets": {
       "get": {
         "description": "Gets the list of namespace secrets",
@@ -963,6 +1871,7 @@
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "After",
             "description": "target namespace",
             "name": "namespace",
             "in": "path",
@@ -1083,6 +1992,41 @@
         "responses": {
           "200": {
             "description": "successfully created directory"
+          }
+        }
+      }
+    },
+    "/api/namespaces/{namespace}/tree/{nodePath}": {
+      "get": {
+        "description": "Gets Workflow and Directory Nodes at nodePath",
+        "tags": [
+          "Directory",
+          "Workflows"
+        ],
+        "summary": "Get List of Namespace Nodes",
+        "operationId": "getNodes",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "After",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "int32",
+            "x-go-name": "First",
+            "description": "target path in tree",
+            "name": "nodePath",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got namespace nodes"
           }
         }
       }
@@ -1276,6 +2220,37 @@
         }
       }
     },
+    "/api/namespaces/{namespace}/tree/{workflow}?op=metrics-invoked": {
+      "get": {
+        "description": "Get metrics of invoked workflow instances",
+        "tags": [
+          "Metrics"
+        ],
+        "summary": "Gets Invoked Workflow Metrics",
+        "operationId": "workflowMetricsInvoked",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "path to target workflow",
+            "name": "workflow",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully got workflow metrics"
+          }
+        }
+      }
+    },
     "/api/namespaces/{namespace}/tree/{workflow}?op=metrics-state-milliseconds": {
       "get": {
         "description": "Get the state timing metrics of a workflow's instance\nThe returns the timing of a individual states in a workflow",
@@ -1334,49 +2309,6 @@
         "responses": {
           "200": {
             "description": "successfully got workflow metrics"
-          }
-        }
-      }
-    },
-    "/api/namespaces/{namespace}/tree/{workflow}?op=save-workflow": {
-      "put": {
-        "description": "Updates a workflow at the target path",
-        "consumes": [
-          "text/plain"
-        ],
-        "tags": [
-          "Workflows"
-        ],
-        "summary": "Update a Workflow",
-        "operationId": "saveWorkflow",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "target namespace",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "path to target workflow",
-            "name": "workflow",
-            "in": "path",
-            "required": true
-          },
-          {
-            "description": "Payload that contains both the JSON data to manipulate and jq query.",
-            "name": "workflow data",
-            "in": "body",
-            "schema": {
-              "type": "string",
-              "example": "description: A simple no-op state that returns Hello world Updated !!!\nstates:\n- id: helloworld\n  type: noop\n  transform:\n    result: Hello world Updated !!!\n"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successfully update workflow"
           }
         }
       }
@@ -1623,10 +2555,11 @@
           "Variables"
         ],
         "summary": "Get List of Workflow Variables",
-        "operationId": "getWorkflowVariableList",
+        "operationId": "getWorkflowVariables",
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "After",
             "description": "target namespace",
             "name": "namespace",
             "in": "path",
@@ -1634,6 +2567,8 @@
           },
           {
             "type": "string",
+            "format": "int32",
+            "x-go-name": "First",
             "description": "path to target workflow",
             "name": "workflow",
             "in": "path",
@@ -1658,6 +2593,7 @@
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "After",
             "description": "target namespace",
             "name": "namespace",
             "in": "path",

--- a/scripts/api/swagger.json
+++ b/scripts/api/swagger.json
@@ -11,7 +11,7 @@
   ],
   "swagger": "2.0",
   "info": {
-    "description": "direktiv api",
+    "description": "Direktiv Open API Specification\nDirektiv Documentation can be found at https://docs.direktiv.io/",
     "title": "Direktiv API.",
     "contact": {
       "email": "info@direktiv.io"
@@ -225,7 +225,7 @@
         }
       },
       "post": {
-        "description": "Creates a new namespace scoped knative service revision\nRevisions are created with a traffic percentage. This percentage controls\nhow much traffic will be directed to this revision. Traffic can be set to 100\nto direct all traffic.",
+        "description": "Creates a new namespace scoped knative service revision\nRevisions are created with a traffic percentage. This percentage controls\nhow much traffic will be directed to this revision. Traffic can be set to 100\nto direct all traffic",
         "tags": [
           "Namespace Services"
         ],
@@ -332,7 +332,7 @@
         }
       },
       "patch": {
-        "description": "traffic can only be configured between two revisions. All other revisions\nwill bet set to 0 traffic.",
+        "description": "traffic can only be configured between two revisions. All other revisions\nwill bet set to 0 traffic",
         "tags": [
           "Namespace Services"
         ],
@@ -788,7 +788,7 @@
         }
       },
       "post": {
-        "description": "Creates a new global scoped knative service revision\nRevisions are created with a traffic percentage. This percentage controls\nhow much traffic will be directed to this revision. Traffic can be set to 100\nto direct all traffic.",
+        "description": "Creates a new global scoped knative service revision\nRevisions are created with a traffic percentage. This percentage controls\nhow much traffic will be directed to this revision. Traffic can be set to 100\nto direct all traffic",
         "tags": [
           "Global Services"
         ],
@@ -881,7 +881,7 @@
         }
       },
       "patch": {
-        "description": "traffic can only be configured between two revisions. All other revisions\nwill bet set to 0 traffic.",
+        "description": "traffic can only be configured between two revisions. All other revisions\nwill bet set to 0 traffic",
         "tags": [
           "Global Services"
         ],
@@ -948,7 +948,34 @@
     },
     "/api/functions/{serviceName}/revisions": {
       "get": {
-        "description": "Watch a global scoped knative service revision\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'\nNote: This is a Server-Sent-Event endpoint",
+        "description": "Watch the revision list of a global scoped knative service\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
+        "produces": [
+          "text/event-stream"
+        ],
+        "tags": [
+          "Global Services"
+        ],
+        "summary": "Watch Global Service Revision List",
+        "operationId": "watchGlobalServiceRevisionList",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target service name",
+            "name": "serviceName",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfully watching service revisions"
+          }
+        }
+      }
+    },
+    "/api/functions/{serviceName}/revisions/{revisionGeneration}": {
+      "get": {
+        "description": "Watch a global scoped knative service revision\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
         "produces": [
           "text/event-stream"
         ],
@@ -1496,10 +1523,11 @@
           "Variables"
         ],
         "summary": "Get List of Instance Variable",
-        "operationId": "getInstanceVariableList",
+        "operationId": "getInstanceVariables",
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "After",
             "description": "target namespace",
             "name": "namespace",
             "in": "path",
@@ -1507,6 +1535,8 @@
           },
           {
             "type": "string",
+            "format": "int32",
+            "x-go-name": "First",
             "description": "target instance",
             "name": "instance",
             "in": "path",
@@ -1558,7 +1588,7 @@
         }
       },
       "put": {
-        "description": "If the target variable does not exists, it will be created.\nVariable data can be anything so long as it can be represented as a string.",
+        "description": "Set the value sorted in a instance variable\nIf the target variable does not exists, it will be created\nVariable data can be anything so long as it can be represented as a string",
         "consumes": [
           "text/plain"
         ],
@@ -2164,7 +2194,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=metrics-failed": {
       "get": {
-        "description": "Get the timing metrics of a workflow's instance\nThis returns a total sum of the milliseconds a workflow has been executed for.",
+        "description": "Get the timing metrics of a workflow's instance\nThis returns a total sum of the milliseconds a workflow has been executed for",
         "tags": [
           "Metrics"
         ],
@@ -2288,7 +2318,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=set-var": {
       "put": {
-        "description": "If the target variable does not exists, it will be created.\nVariable data can be anything so long as it can be represented as a string.",
+        "description": "Set the value sorted in a workflow variable\nIf the target variable does not exists, it will be created\nVariable data can be anything so long as it can be represented as a string",
         "consumes": [
           "text/plain"
         ],
@@ -2340,7 +2370,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=set-workflow-event-logging": {
       "post": {
-        "description": "Set Cloud Event for Workflow to Log to\nWhen configured type `direktiv.instanceLog` cloud events will be generated with the `logger` parameter set to the\nconifgured value.\nWorkflows can be configured to generate cloud events on their namespace\nanything the log parameter produces data. Please find more information on this topic below:\nhttps://docs.direktiv.io/docs/examples/logging.html",
+        "description": "Set Cloud Event for Workflow to Log to\nWhen configured type `direktiv.instanceLog` cloud events will be generated with the `logger` parameter set to the\nconifgured value\nWorkflows can be configured to generate cloud events on their namespace\nanything the log parameter produces data. Please find more information on this topic below:\nhttps://docs.direktiv.io/docs/examples/logging.html",
         "tags": [
           "Workflows"
         ],
@@ -2391,7 +2421,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=toggle": {
       "post": {
-        "description": "Toggle's whether or not a workflow is active\nDisabled workflows cannot be invoked.",
+        "description": "Toggle's whether or not a workflow is active\nDisabled workflows cannot be invoked",
         "tags": [
           "Workflows"
         ],
@@ -2442,7 +2472,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=update-workflow": {
       "post": {
-        "description": "Updates a workflow at the target path\nThe body of this request should contain the workflow yaml you want to update to.",
+        "description": "Updates a workflow at the target path\nThe body of this request should contain the workflow yaml you want to update to",
         "consumes": [
           "text/plain"
         ],
@@ -2611,7 +2641,7 @@
         }
       },
       "put": {
-        "description": "If the target variable does not exists, it will be created.\nVariable data can be anything so long as it can be represented as a string.",
+        "description": "Set the value sorted in a namespace variable\nIf the target variable does not exists, it will be created\nVariable data can be anything so long as it can be represented as a string",
         "consumes": [
           "text/plain"
         ],

--- a/scripts/dev.yaml
+++ b/scripts/dev.yaml
@@ -67,6 +67,6 @@ database:
   host: "direktiv-pgbouncer.postgres.svc"
   port: 5432
   user: "direktiv"
-  password: "}Q_cd;-0}{VRgOaZrO}:2E[|"
+  password: "}o(oPT>RGevQ5iZaQu:{Y[*x"
   name: "direktiv"
   sslmode: require


### PR DESCRIPTION
## Description

Go Swagger Docs added in comments.

## Purpose

- [ ] Bug fix
- [ ] New feature
- [X] Other

## How was this tested? (if applicable)

Running `$ make api-docs; make host=EXT_IP01 api-swagger` will create docs and run a local swagger client to test them.
