### PR TITLE
Scripts fixed to get database connection strings again.

### DIFF
--- a/scripts/printDB.sh
+++ b/scripts/printDB.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 echo "database:
-  host: \"$(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "pgbouncer-host"}}' | base64 --decode)\"
-  port: $(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "pgbouncer-port"}}' | base64 --decode)
+  host: \"$(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "host"}}' | base64 --decode)\"
+  port: $(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "port"}}' | base64 --decode)
   user: \"$(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "user"}}' | base64 --decode)\"
   password: \"$(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "password"}}' | base64 --decode)\"
   name: \"$(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "dbname"}}' | base64 --decode)\"

--- a/scripts/resetAll.sh
+++ b/scripts/resetAll.sh
@@ -86,6 +86,7 @@ helm repo add direktiv https://charts.direktiv.io
 
 helm repo update
 helm search repo direktiv
+helm dependency update $dir/../kubernetes/charts/direktiv
 helm install -n postgres --set singleNamespace=true postgres direktiv/pgo --wait
 kubectl apply -f $dir/../kubernetes/install/db/pg.yaml
 
@@ -95,8 +96,8 @@ countdown
 
 echo ""
 echo "database:
-  host: \"$(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "pgbouncer-host"}}' | base64 --decode)\"
-  port: $(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "pgbouncer-port"}}' | base64 --decode)
+  host: \"$(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "host"}}' | base64 --decode)\"
+  port: $(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "port"}}' | base64 --decode)
   user: \"$(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "user"}}' | base64 --decode)\"
   password: \"$(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "password"}}' | base64 --decode)\"
   name: \"$(kubectl get secrets -n postgres direktiv-pguser-direktiv -o 'go-template={{index .data "dbname"}}' | base64 --decode)\"


### PR DESCRIPTION
Signed-off-by: Jon Alfaro <jon.alfaro@vorteil.io>

## Description

There are parts in these scripts that get the database host and port from Kubernetes secrets. Previously they seemed to get these secrets from the `pgbouncer-host` and `pgbouncer-port` key. 

However recently after `resetAll.sh` It seems that these secret keys have been renamed to `host` and `port` which causes some scripts to error.

```yaml
kc get secrets -n postgres direktiv-pguser-direktiv -o yaml
apiVersion: v1
data:
  dbname: ********
  host: ********
  password: ********
  port: ********
...
```

I'm guessing the prefix was just removed wherever these keys are being set and the script wasn't updated. This pr updates removes the `pgbouncer-` prefix from these keys in the scripts.

