### PR TITLE
go-swagger docs updated to work with jekyll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,15 @@ ent: ## Manually regenerates ent database packages.
 # API docs
 
 .PHONY: api-docs
-api-docs: ## Generates API documentation
+api-docs: ## Generates API documentation, (Also fixes markdown tables & description)
 api-docs:
 	# go get -u github.com/go-swagger/go-swagger/cmd/swagger
 	cd pkg/api
 	swagger generate spec -o scripts/api/swagger.json
 	swagger generate markdown --output scripts/api/api.md -f scripts/api/swagger.json
+	echo "Cleanup markdown tables and descriptions"
+	sed -i -z 's/#### All responses\n|/#### All responses\n\n|/g' scripts/api/api.md
+	sed -i -z 's/description: |//g' scripts/api/api.md
 
 .PHONY: api-swagger
 api-swagger: ## runs swagger server. Use make host=192.168.0.1 api-swagger to change host for API.

--- a/pkg/api/flow.go
+++ b/pkg/api/flow.go
@@ -58,8 +58,9 @@ func newFlowHandler(logger *zap.SugaredLogger, router *mux.Router, conf *util.Co
 func (h *flowHandler) initRoutes(r *mux.Router) {
 
 	// swagger:operation GET /api/namespaces Namespaces getNamespaces
-	// Gets the list of namespaces
 	// ---
+	// description: |
+	//   Gets the list of namespaces.
 	// summary: Gets the list of namespaces
 	// responses:
 	//   '200':
@@ -67,9 +68,10 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_ListNamespaces, "/namespaces", h.Namespaces, h.NamespacesSSE)
 
 	// swagger:operation PUT /api/namespaces/{namespace} Namespaces createNamespace
-	// Creates a new namespace
 	// ---
 	// summary: Creates a namespace
+	// description: |
+	//   Creates a new namespace.
 	// parameters:
 	// - in: path
 	//   name: namespace
@@ -82,8 +84,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}", h.CreateNamespace).Name(RN_AddNamespace).Methods(http.MethodPut)
 
 	// swagger:operation DELETE /api/namespaces/{namespace} Namespaces deleteNamespace
-	// Delete a namespace
 	// ---
+	// description: |
+	//   Delete a namespace.
 	// summary: Delete a namespace
 	// parameters:
 	// - in: path
@@ -97,9 +100,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}", h.DeleteNamespace).Name(RN_DeleteNamespace).Methods(http.MethodDelete)
 
 	// swagger:operation POST /api/jq Other jqPlayground
-	// JQ Playground is a sandbox where
-	// you can test jq queries with custom data
 	// ---
+	// description: |
+	//   JQ Playground is a sandbox where you can test jq queries with custom data.
 	// summary: JQ Playground api to test jq queries
 	// parameters:
 	// - in: body
@@ -126,8 +129,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/jq", h.JQ).Name(RN_JQPlayground).Methods(http.MethodPost)
 
 	// swagger:operation GET /api/logs Logs serverLogs
-	// Gets Direktiv Server Logs
 	// ---
+	// description: |
+	//   Gets Direktiv Server Logs.
 	// summary: Get Direktiv Server Logs
 	// responses:
 	//   '200':
@@ -135,8 +139,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_GetServerLogs, "/logs", h.ServerLogs, h.ServerLogsSSE)
 
 	// swagger:operation GET /api/namespaces/{namespace}/logs Logs namespaceLogs
-	// Gets Namespace Level Logs
 	// ---
+	// description: |
+	//   Gets Namespace Level Logs.
 	// summary: Gets Namespace Level Logs
 	// parameters:
 	// - in: path
@@ -150,8 +155,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_GetNamespaceLogs, "/namespaces/{ns}/logs", h.NamespaceLogs, h.NamespaceLogsSSE)
 
 	// swagger:operation GET /api/namespaces/{namespace}/instances/{instance}/logs Logs instanceLogs
-	// Gets the logs of an executed instance
 	// ---
+	// description: |
+	//   Gets the logs of an executed instance.
 	// summary: Gets Instance Logs
 	// parameters:
 	// - in: path
@@ -170,8 +176,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_GetInstanceLogs, "/namespaces/{ns}/instances/{in}/logs", h.InstanceLogs, h.InstanceLogsSSE)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-invoked Metrics workflowMetricsInvoked
-	// Get metrics of invoked workflow instances
 	// ---
+	// description: |
+	//   Get metrics of invoked workflow instances.
 	// summary: Gets Invoked Workflow Metrics
 	// parameters:
 	// - in: path
@@ -190,8 +197,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodGet, RN_GetWorkflowMetrics, "metrics-invoked", h.WorkflowMetricsInvoked)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-successful Metrics workflowMetricsSuccessful
-	// Get metrics of a workflow, where the instance was successful
 	// ---
+	// description: |
+	//   Get metrics of a workflow, where the instance was successful.
 	// summary: Gets Successful Workflow Metrics
 	// parameters:
 	// - in: path
@@ -210,8 +218,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodGet, RN_GetWorkflowMetrics, "metrics-successful", h.WorkflowMetricsSuccessful)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-failed Metrics workflowMetricsFailed
-	// Get metrics of a workflow, where the instance failed
 	// ---
+	// description: |
+	//   Get metrics of a workflow, where the instance failed.
 	// summary: Gets Failed Workflow Metrics
 	// parameters:
 	// - in: path
@@ -230,9 +239,10 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodGet, RN_GetWorkflowMetrics, "metrics-failed", h.WorkflowMetricsFailed)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-failed Metrics workflowMetricsMilliseconds
-	// Get the timing metrics of a workflow's instance
-	// This returns a total sum of the milliseconds a workflow has been executed for
 	// ---
+	// description: |
+	//   Get the timing metrics of a workflow's instance.
+	//   This returns a total sum of the milliseconds a workflow has been executed for.
 	// summary: Gets Workflow Time Metrics
 	// parameters:
 	// - in: path
@@ -251,9 +261,10 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodGet, RN_GetWorkflowMetrics, "metrics-milliseconds", h.WorkflowMetricsMilliseconds)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-state-milliseconds Metrics workflowMetricsStateMilliseconds
-	// Get the state timing metrics of a workflow's instance
-	// The returns the timing of a individual states in a workflow
 	// ---
+	// description: |
+	//   Get the state timing metrics of a workflow's instance.
+	//   This returns the timing of individual states in a workflow.
 	// summary: Gets a Workflow State Time Metrics
 	// parameters:
 	// - in: path
@@ -272,8 +283,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodGet, RN_GetWorkflowMetrics, "metrics-state-milliseconds", h.WorkflowMetricsStateMilliseconds)
 
 	// swagger:operation GET /api/namespaces/{namespace}/metrics/invoked Metrics namespaceMetricsInvoked
-	// Get metrics of invoked workflows in the targeted namespace
 	// ---
+	// description: |
+	//   Get metrics of invoked workflows in the targeted namespace.
 	// summary: Gets Namespace Invoked Workflow Metrics
 	// parameters:
 	// - in: path
@@ -287,8 +299,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/metrics/invoked", h.NamespaceMetricsInvoked).Name(RN_GetNamespaceMetrics).Methods(http.MethodGet)
 
 	// swagger:operation GET /api/namespaces/{namespace}/metrics/successful Metrics namespaceMetricsSuccessful
-	// Get metrics of successful workflows in the targeted namespace
 	// ---
+	// description: |
+	//   Get metrics of successful workflows in the targeted namespace.
 	// summary: Gets Namespace Successful Workflow Instances Metrics
 	// parameters:
 	// - in: path
@@ -302,8 +315,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/metrics/successful", h.NamespaceMetricsSuccessful).Name(RN_GetNamespaceMetrics).Methods(http.MethodGet)
 
 	// swagger:operation GET /api/namespaces/{namespace}/metrics/failed Metrics namespaceMetricsFailed
-	// Get metrics of failed workflows in the targeted namespace
 	// ---
+	// description: |
+	//   Get metrics of failed workflows in the targeted namespace.
 	// summary: Gets Namespace Failed Workflow Instances Metrics
 	// parameters:
 	// - in: path
@@ -317,8 +331,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/metrics/failed", h.NamespaceMetricsFailed).Name(RN_GetNamespaceMetrics).Methods(http.MethodGet)
 
 	// swagger:operation GET /api/namespaces/{namespace}/metrics/milliseconds Metrics namespaceMetricsMilliseconds
-	// Get timing metrics of workflows in the targeted namespace
 	// ---
+	// description: |
+	//   Get timing metrics of workflows in the targeted namespace.
 	// summary: Gets Namespace Workflow Timing Metrics
 	// parameters:
 	// - in: path
@@ -334,8 +349,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodGet, RN_GetWorkflowMetrics, "metrics-sankey", h.MetricsSankey)
 
 	// swagger:operation GET /api/namespaces/{namespace}/vars/{variable} Variables getNamespaceVariable
-	// Get the value sorted in a namespace variable
 	// ---
+	// description: |
+	//   Get the value sorted in a namespace variable.
 	// summary: Get a Namespace Variable
 	// parameters:
 	// - in: path
@@ -354,8 +370,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/vars/{var}", h.NamespaceVariable).Name(RN_GetNamespaceVariable).Methods(http.MethodGet)
 
 	// swagger:operation DELETE /api/namespaces/{namespace}/vars/{variable} Variables deleteNamespaceVariable
-	// Delete a namespace variable
 	// ---
+	// description: |
+	//   Delete a namespace variable.
 	// summary: Delete a Namespace Variable
 	// parameters:
 	// - in: path
@@ -374,10 +391,11 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/vars/{var}", h.DeleteNamespaceVariable).Name(RN_SetNamespaceVariable).Methods(http.MethodDelete)
 
 	// swagger:operation PUT /api/namespaces/{namespace}/vars/{variable} Variables setNamespaceVariable
-	// Set the value sorted in a namespace variable
-	// If the target variable does not exists, it will be created
-	// Variable data can be anything so long as it can be represented as a string
 	// ---
+	// description: |
+	//   Set the value sorted in a namespace variable.
+	//   If the target variable does not exists, it will be created.
+	//   Variable data can be anything so long as it can be represented as a string.
 	// summary: Set a Namespace Variable
 	// consumes:
 	// - text/plain
@@ -405,8 +423,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/vars/{var}", h.SetNamespaceVariable).Name(RN_SetNamespaceVariable).Methods(http.MethodPut)
 
 	// swagger:operation GET /api/namespaces/{namespace}/vars Variables getNamespaceVariables
-	// Gets a list of variables in a namespace
 	// ---
+	// description: |
+	//   Gets a list of variables in a namespace.
 	// summary: Get Namespace Variable List
 	// parameters:
 	// - in: path
@@ -420,8 +439,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_ListNamespaceVariables, "/namespaces/{ns}/vars", h.NamespaceVariables, h.NamespaceVariablesSSE)
 
 	// swagger:operation GET /api/namespaces/{namespace}/instances/{instance}/vars/{variable} Variables getInstanceVariable
-	// Get the value sorted in a instance variable
 	// ---
+	// description: |
+	//   Get the value sorted in a instance variable.
 	// summary: Get a Instance Variable
 	// parameters:
 	// - in: path
@@ -445,8 +465,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/instances/{instance}/vars/{var}", h.InstanceVariable).Name(RN_GetInstanceVariable).Methods(http.MethodGet)
 
 	// swagger:operation DELETE /api/namespaces/{namespace}/instances/{instance}/vars/{variable} Variables deleteInstanceVariable
-	// Delete a instance variable
 	// ---
+	// description: |
+	//   Delete a instance variable.
 	// summary: Delete a Instance Variable
 	// parameters:
 	// - in: path
@@ -470,10 +491,11 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/instances/{instance}/vars/{var}", h.DeleteInstanceVariable).Name(RN_SetInstanceVariable).Methods(http.MethodDelete)
 
 	// swagger:operation PUT /api/namespaces/{namespace}/instances/{instance}/vars/{variable} Variables setInstanceVariable
-	// Set the value sorted in a instance variable
-	// If the target variable does not exists, it will be created
-	// Variable data can be anything so long as it can be represented as a string
 	// ---
+	// description: |
+	//   Set the value sorted in a instance variable.
+	//   If the target variable does not exists, it will be created.
+	//   Variable data can be anything so long as it can be represented as a string.
 	// summary: Set a Instance Variable
 	// consumes:
 	// - text/plain
@@ -506,8 +528,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/instances/{instance}/vars/{var}", h.SetInstanceVariable).Name(RN_SetInstanceVariable).Methods(http.MethodPut)
 
 	// swagger:operation GET /api/namespaces/{namespace}/instances/{instance}/vars Variables getInstanceVariables
-	// Gets a list of variables in a instance
 	// ---
+	// description: |
+	//   Gets a list of variables in a instance.
 	// summary: Get List of Instance Variable
 	// parameters:
 	// - in: path
@@ -526,8 +549,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_ListInstanceVariables, "/namespaces/{ns}/instances/{instance}/vars", h.InstanceVariables, h.InstanceVariablesSSE)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=var Variables getWorkflowVariable
-	// Get the value sorted in a workflow variable
 	// ---
+	// description: |
+	//   Get the value sorted in a workflow variable.
 	// summary: Get a Workflow Variable
 	// parameters:
 	// - in: path
@@ -551,8 +575,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodGet, RN_GetWorkflowVariable, "var", h.WorkflowVariable)
 
 	// swagger:operation DELETE /api/namespaces/{namespace}/tree/{workflow}?op=delete-var Variables deleteWorkflowVariable
-	// Delete a workflow variable
 	// ---
+	// description: |
+	//   Delete a workflow variable.
 	// summary: Delete a Workflow Variable
 	// parameters:
 	// - in: path
@@ -576,10 +601,11 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodDelete, RN_SetWorkflowVariable, "delete-var", h.DeleteWorkflowVariable)
 
 	// swagger:operation PUT /api/namespaces/{namespace}/tree/{workflow}?op=set-var Variables setWorkflowVariable
-	// Set the value sorted in a workflow variable
-	// If the target variable does not exists, it will be created
-	// Variable data can be anything so long as it can be represented as a string
 	// ---
+	// description: |
+	//   Set the value sorted in a workflow variable.
+	//   If the target variable does not exists, it will be created.
+	//   Variable data can be anything so long as it can be represented as a string.
 	// summary: Set a Workflow Variable
 	// consumes:
 	// - text/plain
@@ -612,8 +638,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodPut, RN_SetWorkflowVariable, "set-var", h.SetWorkflowVariable)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=vars Variables getWorkflowVariables
-	// Gets a list of variables in a workflow
 	// ---
+	// description: |
+	//   Gets a list of variables in a workflow.
 	// summary: Get List of Workflow Variables
 	// parameters:
 	// - in: path
@@ -632,8 +659,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandlerPair(r, RN_ListWorkflowVariables, "vars", h.WorkflowVariables, h.WorkflowVariablesSSE)
 
 	// swagger:operation GET /api/namespaces/{namespace}/secrets Secrets getSecrets
-	// Gets the list of namespace secrets
 	// ---
+	// description: |
+	//   Gets the list of namespace secrets.
 	// summary: Get List of Namespace Secrets
 	// parameters:
 	// - in: path
@@ -647,8 +675,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_ListSecrets, "/namespaces/{ns}/secrets", h.Secrets, h.SecretsSSE)
 
 	// swagger:operation PUT /api/namespaces/{namespace}/secrets/{secret} Secrets createSecret
-	// Create a namespace secret
 	// ---
+	// description: |
+	//   Create a namespace secret.
 	// summary: Create a Namespace Secret
 	// parameters:
 	// - in: path
@@ -680,8 +709,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/secrets/{secret}", h.SetSecret).Name(RN_CreateSecret).Methods(http.MethodPut)
 
 	// swagger:operation DELETE /api/namespaces/{namespace}/secrets/{secret} Secrets deleteSecret
-	// Delete a namespace secret
 	// ---
+	// description: |
+	//   Delete a namespace secret.
 	// summary: Delete a Namespace Secret
 	// parameters:
 	// - in: path
@@ -700,8 +730,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/secrets/{secret}", h.DeleteSecret).Name(RN_DeleteSecret).Methods(http.MethodDelete)
 
 	// swagger:operation GET /api/namespaces/{namespace}/instances/{instance} Instances getInstance
-	// Gets the details of a executed workflow instance in this namespace
 	// ---
+	// description: |
+	//   Gets the details of a executed workflow instance in this namespace.
 	// summary: Get a Instance
 	// parameters:
 	// - in: path
@@ -720,8 +751,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_GetInstance, "/namespaces/{ns}/instances/{instance}", h.Instance, h.InstanceSSE)
 
 	// swagger:operation GET /api/namespaces/{namespace}/instances Instances getInstanceList
-	// Gets a list of instances in a namespace
 	// ---
+	// description: |
+	//   Gets a list of instances in a namespace.
 	// summary: Get List Instances
 	// parameters:
 	// - in: path
@@ -735,8 +767,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_ListInstances, "/namespaces/{ns}/instances", h.Instances, h.InstancesSSE)
 
 	// swagger:operation GET /api/namespaces/{namespace}/instances/{instance}/input Instances getInstanceInput
-	// Gets the input an instance was provided when executed
 	// ---
+	// description: |
+	//   Gets the input an instance was provided when executed.
 	// summary: Get a Instance Input
 	// parameters:
 	// - in: path
@@ -755,8 +788,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/instances/{instance}/input", h.InstanceInput).Name(RN_GetInstance).Methods(http.MethodGet)
 
 	// swagger:operation GET /api/namespaces/{namespace}/instances/{instance}/output Instances getInstanceOutput
-	// Gets the output an instance was provided when executed
 	// ---
+	// description: |
+	//   Gets the output an instance was provided when executed.
 	// summary: Get a Instance Output
 	// parameters:
 	// - in: path
@@ -775,8 +809,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/instances/{instance}/output", h.InstanceOutput).Name(RN_GetInstance).Methods(http.MethodGet)
 
 	// swagger:operation POST /api/namespaces/{namespace}/instances/{instance}/cancel Instances cancelInstance
-	// Cancel a currently pending instance
 	// ---
+	// description: |
+	//   Cancel a currently pending instance.
 	// summary: Cancel a Pending Instance
 	// parameters:
 	// - in: path
@@ -795,10 +830,11 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/instances/{instance}/cancel", h.InstanceCancel).Name(RN_CancelInstance).Methods(http.MethodPost)
 
 	// swagger:operation POST /api/namespaces/{namespace}/broadcast Other broadcastCloudevent
-	// Broadcast a cloud event to a namespace
-	// Cloud events posted to this api will be picked up by any workflows listening to the same event type on the namescape.
-	// The body of this request should follow the cloud event core specification defined at https://github.com/cloudevents/spec
 	// ---
+	// description: |
+	//   Broadcast a cloud event to a namespace.
+	//   Cloud events posted to this api will be picked up by any workflows listening to the same event type on the namescape.
+	//   The body of this request should follow the cloud event core specification defined at https://github.com/cloudevents/spec .
 	// summary: Broadcast Cloud Event
 	// parameters:
 	// - in: path
@@ -817,8 +853,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/broadcast", h.BroadcastCloudevent).Name(RN_NamespaceEvent).Methods(http.MethodPost)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=logs Logs getWorkflowLogs
-	// Get workflow level logs
 	// ---
+	// description: |
+	//   Get workflow level logs.
 	// summary: Get Workflow Level Logs
 	// parameters:
 	// - in: path
@@ -837,8 +874,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandlerPair(r, RN_GetWorkflowLogs, "logs", h.WorkflowLogs, h.WorkflowLogsSSE)
 
 	// swagger:operation PUT /api/namespaces/{namespace}/tree/{directory}?op=create-directory Directory createDirectory
-	// Creates a directory at the target path
 	// ---
+	// description: |
+	//   Creates a directory at the target path.
 	// summary: Create a Directory
 	// parameters:
 	// - in: path
@@ -857,9 +895,10 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodPut, RN_CreateDirectory, "create-directory", h.CreateDirectory)
 
 	// swagger:operation PUT /api/namespaces/{namespace}/tree/{workflow}?op=create-workflow Workflows createWorkflow
-	// Creates a workflow at the target path
-	// The body of this request should contain the workflow yaml
 	// ---
+	// description: |
+	//   Creates a workflow at the target path.
+	//   The body of this request should contain the workflow yaml.
 	// summary: Create a Workflow
 	// consumes:
 	// - text/plain
@@ -892,9 +931,10 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodPut, RN_CreateWorkflow, "create-workflow", h.CreateWorkflow)
 
 	// swagger:operation POST /api/namespaces/{namespace}/tree/{workflow}?op=update-workflow Workflows updateWorkflow
-	// Updates a workflow at the target path
-	// The body of this request should contain the workflow yaml you want to update to
 	// ---
+	// description: |
+	//   Updates a workflow at the target path.
+	//   The body of this request should contain the workflow yaml you want to update to.
 	// summary: Update a Workflow
 	// consumes:
 	// - text/plain
@@ -962,13 +1002,13 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodPost, RN_ValidateRouter, "validate-router", h.ValidateRouter)
 
 	// swagger:operation POST /api/namespaces/{namespace}/tree/{workflow}?op=set-workflow-event-logging Workflows setWorkflowCloudEventLogs
-	// Set Cloud Event for Workflow to Log to
-	// When configured type `direktiv.instanceLog` cloud events will be generated with the `logger` parameter set to the
-	// conifgured value
-	// Workflows can be configured to generate cloud events on their namespace
-	// anything the log parameter produces data. Please find more information on this topic below:
-	// https://docs.direktiv.io/docs/examples/logging.html
 	// ---
+	// description: |
+	//   Set Cloud Event for Workflow to Log to.
+	//   When configured type `direktiv.instanceLog` cloud events will be generated with the `logger` parameter set to the configured value.
+	//   Workflows can be configured to generate cloud events on their namespace anything the log parameter produces data.
+	//   Please find more information on this topic here:
+	//   https://docs.direktiv.io/docs/examples/logging.html
 	// summary: Set Cloud Event for Workflow to Log to
 	// parameters:
 	// - in: path
@@ -1000,9 +1040,10 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodPost, RN_UpdateWorkflow, "set-workflow-event-logging", h.SetWorkflowEventLogging)
 
 	// swagger:operation POST /api/namespaces/{namespace}/tree/{workflow}?op=toggle Workflows toggleWorkflow
-	// Toggle's whether or not a workflow is active
-	// Disabled workflows cannot be invoked
 	// ---
+	// description: |
+	//   Toggle's whether or not a workflow is active.
+	//   Disabled workflows cannot be invoked. This includes start event and scheduled workflows.
 	// summary: Set Cloud Event for Workflow to Log to
 	// parameters:
 	// - in: path
@@ -1034,8 +1075,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodPost, RN_UpdateWorkflow, "toggle", h.ToggleWorkflow)
 
 	// swagger:operation POST /api/namespaces/{namespace}/tree/{workflow}?op=execute Workflows executeWorkflow
-	// Executes a workflow with optionally some input provided in the request body as json
 	// ---
+	// description: |
+	//   Executes a workflow with optionally some input provided in the request body as json.
 	// summary: Execute a Workflow
 	// parameters:
 	// - in: path
@@ -1065,12 +1107,13 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodPost, RN_ExecuteWorkflow, "execute", h.ExecuteWorkflow)
 
 	// swagger:operation POST /api/namespaces/{namespace}/tree/{workflow}?op=wait Workflows awaitExecuteWorkflowBody
-	// Executes a workflow with optionally some input provided in the request body as json
-	// This path will wait until the workflow execution has completed and return the instance output
-	// NOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json
-	// key. Only top level json keys are supported when providing input with query parameters. Input query
-	// parameters are only read if the request has not body
 	// ---
+	// description: |
+	//   Executes a workflow with optionally some input provided in the request body as json.
+	//   This path will wait until the workflow execution has completed and return the instance output.
+	//   NOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json key.
+	//   Only top level json keys are supported when providing input with query parameters.
+	//   Input query parameters are only read if the request has no body.
 	// summary: Await Execute a Workflow With Body
 	// parameters:
 	// - in: path
@@ -1115,10 +1158,11 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodPost, RN_ExecuteWorkflow, "wait", h.WaitWorkflow)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=wait Workflows awaitExecuteWorkflow
-	// Executes a workflow. This path will wait until the workflow execution has completed and return the instance output
-	// NOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json
-	// key. Only top level json keys are supported when providing input with query parameters
 	// ---
+	// description: |
+	//   Executes a workflow. This path will wait until the workflow execution has completed and return the instance output.
+	//   NOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json key.
+	//   Only top level json keys are supported when providing input with query parameters.
 	// summary: Await Execute a Workflow
 	// parameters:
 	// - in: path
@@ -1152,8 +1196,9 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodGet, RN_ExecuteWorkflow, "wait", h.WaitWorkflow)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{nodePath} Registries getNodes
-	// Gets Workflow and Directory Nodes at nodePath
 	// ---
+	// description: |
+	//   Gets Workflow and Directory Nodes at nodePath.
 	// summary: Get List of Namespace Nodes
 	// tags:
 	// - "Directory"

--- a/pkg/api/flow.go
+++ b/pkg/api/flow.go
@@ -679,6 +679,8 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	// description: |
 	//   Create a namespace secret.
 	// summary: Create a Namespace Secret
+	// consumes:
+	// - text/plain
 	// parameters:
 	// - in: path
 	//   name: namespace
@@ -692,17 +694,10 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	//   description: 'target secret'
 	// - in: body
 	//   name: Secret Payload
-	//   description: Payload that contains secret data
+	//   description: "Payload that contains secret data."
 	//   schema:
-	//     example:
-	//       data: "8QwFLg%D$qg*3r++`{D<BAp~4mB49^"
-	//     type: object
-	//     required:
-	//       - data
-	//     properties:
-	//       data:
-	//         type: string
-	//         description: Secret data to be set
+	//     example: 7F8E7B0124ACB2BD20B383DE0756C7C0
+	//     type: string
 	// responses:
 	//   '200':
 	//     "description": "successfully created namespace secret"

--- a/pkg/api/functions.go
+++ b/pkg/api/functions.go
@@ -75,8 +75,9 @@ func newFunctionHandler(srv *Server, logger *zap.SugaredLogger,
 func (h *functionHandler) initRoutes(r *mux.Router) {
 
 	// swagger:operation GET /api/functions getGlobalServiceList
-	// Gets a list of global knative services
 	// ---
+	// description: |
+	//   Gets a list of global knative services.
 	// summary: Get Global Services List
 	// tags:
 	// - "Global Services"
@@ -86,10 +87,11 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_ListServices, "", h.listGlobalServices, h.listGlobalServicesSSE)
 
 	// swagger:operation GET /api/functions/{serviceName}/revisions/{revisionGeneration}/pods listGlobalServiceRevisionPods
-	// List a revisions pods of a global scoped knative service
-	// The target revision generation is the number suffix on a revision
-	// Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
 	// ---
+	// description: |
+	//   List a revisions pods of a global scoped knative service.
+	//   The target revision generation is the number suffix on a revision.
+	//   Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003' .
 	// summary: Get Global Service Revision Pods List
 	// tags:
 	// - "Global Services"
@@ -110,9 +112,10 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_ListPods, "/{svn}/revisions/{rev}/pods", h.listGlobalPods, h.listGlobalPodsSSE)
 
 	// swagger:operation GET /api/functions/{serviceName} watchGlobalServiceRevisionList
-	// Watch the revision list of a global scoped knative service
-	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
 	// ---
+	// description: |
+	//   Watch the revision list of a global scoped knative service.
+	//   Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
 	// summary: Watch Global Service Revision
 	// tags:
 	// - "Global Services"
@@ -130,9 +133,10 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/{svn}", h.singleGlobalServiceSSE).Name(RN_WatchServices).Methods(http.MethodGet).Headers("Accept", "text/event-stream")
 
 	// swagger:operation GET /api/functions/{serviceName}/revisions watchGlobalServiceRevisionList
-	// Watch the revision list of a global scoped knative service
-	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
 	// ---
+	// description: |
+	//   Watch the revision list of a global scoped knative service.
+	//   Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
 	// summary: Watch Global Service Revision List
 	// tags:
 	// - "Global Services"
@@ -150,11 +154,12 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/{svn}/revisions", h.watchGlobalRevisions).Name(RN_WatchRevisions).Methods(http.MethodGet).Headers("Accept", "text/event-stream")
 
 	// swagger:operation GET /api/functions/{serviceName}/revisions/{revisionGeneration} watchGlobalServiceRevision
-	// Watch a global scoped knative service revision
-	// The target revision generation is the number suffix on a revision
-	// Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
-	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
 	// ---
+	// description: |
+	//   Watch a global scoped knative service revision.
+	//   The target revision generation is the number suffix on a revision.
+	//   Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'.
+	//   Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
 	// summary: Watch Global Service Revision
 	// tags:
 	// - "Global Services"
@@ -180,11 +185,12 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/logs/pod/{pod}", h.watchLogs).Methods(http.MethodGet).Name(RN_WatchLogs)
 
 	// swagger:operation POST /api/functions createGlobalService
-	// Creates global scoped knative service
-	// Service Names are unique on a scope level
-	// These services can be used as functions in workflows, more about this can be read here:
-	// https://docs.direktiv.io/docs/walkthrough/using-functions.html
 	// ---
+	// description: |
+	//   Creates global scoped knative service.
+	//   Service Names are unique on a scope level.
+	//   These services can be used as functions in workflows, more about this can be read here:
+	//   https://docs.direktiv.io/docs/walkthrough/using-functions.html
 	// summary: Create Global Service
 	// tags:
 	// - "Global Services"
@@ -232,8 +238,9 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("", h.createGlobalService).Methods(http.MethodPost).Name(RN_CreateService)
 
 	// swagger:operation DELETE /api/functions/{serviceName} deleteGlobalService
-	// Deletes global scoped knative service and all its revisions
 	// ---
+	// description: |
+	//   Deletes global scoped knative service and all its revisions.
 	// summary: Delete Global Service
 	// tags:
 	// - "Global Services"
@@ -249,8 +256,9 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/{svn}", h.deleteGlobalService).Methods(http.MethodDelete).Name(RN_DeleteServices)
 
 	// swagger:operation GET /api/functions/{serviceName} getGlobalService
-	// Get details of a global scoped knative service
 	// ---
+	// description: |
+	//   Get details of a global scoped knative service.
 	// summary: Get Global Service Details
 	// tags:
 	// - "Global Services"
@@ -266,11 +274,11 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/{svn}", h.getGlobalService).Methods(http.MethodGet).Name(RN_GetService)
 
 	// swagger:operation POST /api/functions/{serviceName} updateGlobalService
-	// Creates a new global scoped knative service revision
-	// Revisions are created with a traffic percentage. This percentage controls
-	// how much traffic will be directed to this revision. Traffic can be set to 100
-	// to direct all traffic
 	// ---
+	// description: |
+	//   Creates a new global scoped knative service revision
+	//   Revisions are created with a traffic percentage. This percentage controls how much traffic will be directed to this revision.
+	//   Traffic can be set to 100 to direct all traffic.
 	// summary: Create Global Service Revision
 	// tags:
 	// - "Global Services"
@@ -323,10 +331,10 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/{svn}", h.updateGlobalService).Methods(http.MethodPost).Name(RN_UpdateService)
 
 	// swagger:operation PATCH /api/functions/{serviceName} updateGlobalServiceTraffic
-	// Update Global Service traffic directed to each revision,
-	// traffic can only be configured between two revisions. All other revisions
-	// will bet set to 0 traffic
 	// ---
+	// description: |
+	//   Update Global Service traffic directed to each revision, traffic can only be configured between two revisions.
+	//   All other revisions will bet set to 0 traffic.
 	// summary: Update Global Service Traffic
 	// tags:
 	// - "Global Services"
@@ -370,11 +378,12 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/{svn}", h.updateGlobalServiceTraffic).Methods(http.MethodPatch).Name(RN_UpdateServiceTraffic)
 
 	// swagger:operation DELETE /api/functions/{serviceName}/revisions/{revisionGeneration} deleteGlobalRevision
-	// Delete a global scoped knative service revision
-	// The target revision generation is the number suffix on a revision
-	// Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
-	// Note: Revisions with traffic cannot be deleted
 	// ---
+	// description: |
+	//   Delete a global scoped knative service revision.
+	//   The target revision generation is the number suffix on a revision.
+	//   Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'.
+	//   Note: Revisions with traffic cannot be deleted.
 	// summary: Delete Global Service Revision
 	// tags:
 	// - "Global Services"
@@ -397,8 +406,9 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	// namespace
 
 	// swagger:operation GET /api/functions/namespaces/{namespace} getNamespaceServiceList
-	// Gets a list of namespace knative services
 	// ---
+	// description: |
+	//   Gets a list of namespace knative services.
 	// summary: Get Namespace Services List
 	// tags:
 	// - "Namespace Services"
@@ -414,10 +424,11 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_ListNamespaceServices, "/namespaces/{ns}", h.listNamespaceServices, h.listNamespaceServicesSSE)
 
 	// swagger:operation GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}/pods listNamespaceServiceRevisionPods
-	// List a revisions pods of a namespace scoped knative service
-	// The target revision generation is the number suffix on a revision
-	// Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
 	// ---
+	// description: |
+	//   List a revisions pods of a namespace scoped knative service.
+	//   The target revision generation is the number suffix on a revision.
+	//   Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'.
 	// summary: Get Namespace Service Revision Pods List
 	// tags:
 	// - "Namespace Services"
@@ -443,9 +454,10 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	handlerPair(r, RN_ListNamespacePods, "/namespaces/{ns}/function/{svn}/revisions/{rev}/pods", h.listNamespacePods, h.listNamespacePodsSSE)
 
 	// swagger:operation GET /api/functions/namespaces/{namespace}/function/{serviceName} watchNamespaceServiceRevisionList
-	// Watch the revision list of a namespace scoped knative service
-	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
 	// ---
+	// description: |
+	//   Watch the revision list of a namespace scoped knative service.
+	//   Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
 	// summary: Watch Namespace Service Revision
 	// tags:
 	// - "Namespace Services"
@@ -468,9 +480,10 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/function/{svn}", h.singleNamespaceServiceSSE).Name(RN_WatchServices).Methods(http.MethodGet).Headers("Accept", "text/event-stream")
 
 	// swagger:operation GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions watchNamespaceServiceRevisionList
-	// Watch the revision list of a namespace scoped knative service
-	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
 	// ---
+	// description: |
+	//   Watch the revision list of a namespace scoped knative service.
+	//   Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
 	// summary: Watch Namespace Service Revision List
 	// tags:
 	// - "Namespace Services"
@@ -493,11 +506,12 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/function/{svn}/revisions", h.watchNamespaceRevisions).Name(RN_WatchRevisions).Methods(http.MethodGet).Headers("Accept", "text/event-stream")
 
 	// swagger:operation GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration} watchNamespaceServiceRevision
-	// Watch a namespace scoped knative service revision
-	// The target revision generation is the number suffix on a revision
-	// Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
-	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
 	// ---
+	// description: |
+	//   Watch a namespace scoped knative service revision.
+	//   The target revision generation is the number suffix on a revision.
+	//   Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'.
+	//   Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
 	// summary: Watch Namespace Service Revision
 	// tags:
 	// - "Namespace Services"
@@ -525,11 +539,12 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/function/{svn}/revisions/{rev}", h.watchNamespaceRevision).Name(RN_WatchRevisions).Methods(http.MethodGet).Headers("Accept", "text/event-stream")
 
 	// swagger:operation POST /api/functions/namespaces/{namespace} createNamespaceService
-	// Creates namespace scoped knative service
-	// Service Names are unique on a scope level
-	// These services can be used as functions in workflows, more about this can be read here:
-	// https://docs.direktiv.io/docs/walkthrough/using-functions.html
 	// ---
+	// description: |
+	//   Creates namespace scoped knative service.
+	//   Service Names are unique on a scope level.
+	//   These services can be used as functions in workflows, more about this can be read here:
+	//   https://docs.direktiv.io/docs/walkthrough/using-functions.html
 	// summary: Create Namespace Service
 	// tags:
 	// - "Namespace Services"
@@ -582,8 +597,9 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}", h.createNamespaceService).Methods(http.MethodPost).Name(RN_CreateNamespaceService)
 
 	// swagger:operation DELETE /api/functions/namespaces/{namespace}/function/{serviceName} deleteNamespaceService
-	// Deletes namespace scoped knative service and all its revisions
 	// ---
+	// description: |
+	//   Deletes namespace scoped knative service and all its revisions.
 	// summary: Delete Namespace Service
 	// tags:
 	// - "Namespace Services"
@@ -604,8 +620,9 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/function/{svn}", h.deleteNamespaceService).Methods(http.MethodDelete).Name(RN_DeleteNamespaceServices)
 
 	// swagger:operation GET /api/functions/namespaces/{namespace}/function/{serviceName} getNamespaceService
-	// Get details of a namespace scoped knative service
 	// ---
+	// description: |
+	//   Get details of a namespace scoped knative service.
 	// summary: Get Namespace Service Details
 	// tags:
 	// - "Namespace Services"
@@ -626,11 +643,12 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/function/{svn}", h.getNamespaceService).Methods(http.MethodGet).Name(RN_GetNamespaceService)
 
 	// swagger:operation POST /api/functions/namespaces/{namespace}/function/{serviceName} updateNamespaceService
-	// Creates a new namespace scoped knative service revision
-	// Revisions are created with a traffic percentage. This percentage controls
-	// how much traffic will be directed to this revision. Traffic can be set to 100
-	// to direct all traffic
 	// ---
+	// description: |
+	//   Creates a new namespace scoped knative service revision.
+	//   Revisions are created with a traffic percentage. This percentage controls
+	//   how much traffic will be directed to this revision. Traffic can be set to 100
+	//   to direct all traffic.
 	// summary: Create Namespace Service Revision
 	// tags:
 	// - "Namespace Services"
@@ -688,10 +706,11 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/function/{svn}", h.updateNamespaceService).Methods(http.MethodPost).Name(RN_UpdateNamespaceService)
 
 	// swagger:operation PATCH /api/functions/namespaces/{namespace}/function/{serviceName} updateNamespaceServiceTraffic
-	// Update Namespace Service traffic directed to each revision,
-	// traffic can only be configured between two revisions. All other revisions
-	// will bet set to 0 traffic
 	// ---
+	// description: |
+	//   Update Namespace Service traffic directed to each revision,
+	//   traffic can only be configured between two revisions. All other revisions
+	//   will bet set to 0 traffic.
 	// summary: Update Namespace Service Traffic
 	// tags:
 	// - "Namespace Services"
@@ -740,11 +759,12 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/function/{svn}", h.updateNamespaceServiceTraffic).Methods(http.MethodPatch).Name(RN_UpdateNamespaceServiceTraffic)
 
 	// swagger:operation DELETE /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration} deleteNamespaceRevision
-	// Delete a namespace scoped knative service revision
-	// The target revision generation is the number suffix on a revision
-	// Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
-	// Note: Revisions with traffic cannot be deleted
 	// ---
+	// description: |
+	//   Delete a namespace scoped knative service revision.
+	//   The target revision generation is the number suffix on a revision.
+	//   Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'.
+	//   Note: Revisions with traffic cannot be deleted.
 	// summary: Delete Namespace Service Revision
 	// tags:
 	// - "Namespace Services"
@@ -772,8 +792,9 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	// workflow
 
 	// swagger:operation GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=services listWorkflowServices
-	// Gets a list of workflow knative services
 	// ---
+	// description: |
+	//   Gets a list of workflow knative services.
 	// summary: Get Workflow Services List
 	// parameters:
 	// - in: path
@@ -794,10 +815,11 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	pathHandlerPair(r, RN_ListWorkflowServices, "services", h.listWorkflowServices, h.listWorkflowServicesSSE)
 
 	// swagger:operation GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=pods listWorkflowServiceRevisionPods
-	// List a revisions pods of a workflow scoped knative service
-	// The target revision generation (rev query) is the number suffix on a revision
-	// Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'
 	// ---
+	// description: |
+	//   List a revisions pods of a workflow scoped knative service.
+	//   The target revision generation (rev query) is the number suffix on a revision.
+	//   Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'.
 	// summary: Get Workflow Service Revision Pods List
 	// tags:
 	// - "Workflow Services"
@@ -828,9 +850,10 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	pathHandlerPair(r, RN_ListWorkflowServices, "pods", h.listWorkflowPods, h.listWorkflowPodsSSE)
 
 	// swagger:operation GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function getWorkflowService
-	// Get a workflow scoped knative service details
-	// Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
 	// ---
+	// description: |
+	//   Get a workflow scoped knative service details.
+	//   Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
 	// summary: Get Workflow Service Details
 	// tags:
 	// - "Workflow Services"
@@ -861,8 +884,9 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	pathHandlerPair(r, RN_ListWorkflowServices, "function", h.singleWorkflowService, h.singleWorkflowServiceSSE)
 
 	// swagger:operation GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revisions getWorkflowServiceRevisionList
-	// Get the revision list of a workflow scoped knative service
 	// ---
+	// description: |
+	//   Get the revision list of a workflow scoped knative service.
 	// summary: Get Workflow Service Revision List
 	// tags:
 	// - "Workflow Services"
@@ -893,11 +917,12 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	pathHandlerPair(r, RN_ListWorkflowServices, "function-revisions", h.singleWorkflowServiceRevisions, h.singleWorkflowServiceRevisionsSSE)
 
 	// swagger:operation GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revision getWorkflowServiceRevision
-	// Get a workflow scoped knative service revision
-	// This will return details on a single revision
-	// The target revision generation (rev query) is the number suffix on a revision
-	// Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'
 	// ---
+	// description: |
+	//   Get a workflow scoped knative service revision.
+	//   This will return details on a single revision.
+	//   The target revision generation (rev query) is the number suffix on a revision.
+	//   Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'.
 	// summary: Get Workflow Service Revision
 	// tags:
 	// - "Workflow Services"
@@ -938,8 +963,9 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	// Registry ..
 
 	// swagger:operation GET /api/namespaces/{namespace}/registries Registries getRegistries
-	// Gets the list of namespace registries
 	// ---
+	// description: |
+	//   Gets the list of namespace registries.
 	// summary: Get List of Namespace Registries
 	// parameters:
 	// - in: path
@@ -953,11 +979,12 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/registries", h.getRegistries).Methods(http.MethodGet).Name(RN_ListRegistries)
 
 	// swagger:operation POST /api/namespaces/{namespace}/registries Registries createRegistry
-	// Create a namespace container registry
-	// This can be used to connect your workflows to private container registries that require tokens
-	// The data property in the body is made up from the registry user and token. It follows the pattern defined below:
-	// data=USER:TOKEN
 	// ---
+	// description: |
+	//   Create a namespace container registry.
+	//   This can be used to connect your workflows to private container registries that require tokens.
+	//   The data property in the body is made up from the registry user and token. It follows the pattern :
+	//   data=USER:TOKEN
 	// summary: Create a Namespace Container Registry
 	// parameters:
 	// - in: path
@@ -989,8 +1016,9 @@ func (h *functionHandler) initRoutes(r *mux.Router) {
 	r.HandleFunc("/namespaces/{ns}/registries", h.createRegistry).Methods(http.MethodPost).Name(RN_CreateRegistry)
 
 	// swagger:operation POST /api/namespaces/{namespace}/registries Registries deleteRegistry
-	// Delete a namespace container registry
 	// ---
+	// description: |
+	//   Delete a namespace container registry
 	// summary: Delete a Namespace Container Registry
 	// parameters:
 	// - in: path

--- a/scripts/api/api.md
+++ b/scripts/api/api.md
@@ -217,9 +217,10 @@ Direktiv Documentation can be found at https://docs.direktiv.io/
 GET /api/namespaces/{namespace}/tree/{workflow}?op=wait
 ```
 
-Executes a workflow. This path will wait until the workflow execution has completed and return the instance output
-NOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json
-key. Only top level json keys are supported when providing input with query parameters
+Executes a workflow. This path will wait until the workflow execution has completed and return the instance output.
+NOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json key.
+Only top level json keys are supported when providing input with query parameters.
+
 
 #### Parameters
 
@@ -232,6 +233,7 @@ key. Only top level json keys are supported when providing input with query para
 | raw-output | `query` | boolean | `bool` |  |  |  | If set to true, will return an empty output as null, encoded base64 data as decoded binary data, and quoted json strings as a escaped string. |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#await-execute-workflow-200) | OK | successfully executed workflow |  | [schema](#await-execute-workflow-200-schema) |
@@ -250,11 +252,12 @@ Status: OK
 POST /api/namespaces/{namespace}/tree/{workflow}?op=wait
 ```
 
-Executes a workflow with optionally some input provided in the request body as json
-This path will wait until the workflow execution has completed and return the instance output
-NOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json
-key. Only top level json keys are supported when providing input with query parameters. Input query
-parameters are only read if the request has not body
+Executes a workflow with optionally some input provided in the request body as json.
+This path will wait until the workflow execution has completed and return the instance output.
+NOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json key.
+Only top level json keys are supported when providing input with query parameters.
+Input query parameters are only read if the request has no body.
+
 
 #### Parameters
 
@@ -268,6 +271,7 @@ parameters are only read if the request has not body
 | Workflow Input | `body` | [interface{}](#interface) | `interface{}` | |  | | The input of this workflow instance |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#await-execute-workflow-body-200) | OK | successfully executed workflow |  | [schema](#await-execute-workflow-body-200-schema) |
@@ -286,9 +290,10 @@ Status: OK
 POST /api/namespaces/{namespace}/broadcast
 ```
 
-Broadcast a cloud event to a namespace
+Broadcast a cloud event to a namespace.
 Cloud events posted to this api will be picked up by any workflows listening to the same event type on the namescape.
-The body of this request should follow the cloud event core specification defined at https://github.com/cloudevents/spec
+The body of this request should follow the cloud event core specification defined at https://github.com/cloudevents/spec .
+
 
 #### Parameters
 
@@ -298,6 +303,7 @@ The body of this request should follow the cloud event core specification define
 | cloudevent | `body` | [interface{}](#interface) | `interface{}` | |  | | Cloud Event request to be sent. |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#broadcast-cloudevent-200) | OK | successfully sent cloud event |  | [schema](#broadcast-cloudevent-200-schema) |
@@ -316,7 +322,8 @@ Status: OK
 POST /api/namespaces/{namespace}/instances/{instance}/cancel
 ```
 
-Cancel a currently pending instance
+Cancel a currently pending instance.
+
 
 #### Parameters
 
@@ -326,6 +333,7 @@ Cancel a currently pending instance
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#cancel-instance-200) | OK | successfully cancelled instance |  | [schema](#cancel-instance-200-schema) |
@@ -344,7 +352,8 @@ Status: OK
 PUT /api/namespaces/{namespace}/tree/{directory}?op=create-directory
 ```
 
-Creates a directory at the target path
+Creates a directory at the target path.
+
 
 #### Parameters
 
@@ -354,6 +363,7 @@ Creates a directory at the target path
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#create-directory-200) | OK | successfully created directory |  | [schema](#create-directory-200-schema) |
@@ -372,10 +382,11 @@ Status: OK
 POST /api/functions
 ```
 
-Creates global scoped knative service
-Service Names are unique on a scope level
+Creates global scoped knative service.
+Service Names are unique on a scope level.
 These services can be used as functions in workflows, more about this can be read here:
 https://docs.direktiv.io/docs/walkthrough/using-functions.html
+
 
 #### Parameters
 
@@ -384,6 +395,7 @@ https://docs.direktiv.io/docs/walkthrough/using-functions.html
 | Service | `body` | [CreateGlobalServiceBody](#create-global-service-body) | `CreateGlobalServiceBody` | | ✓ | | Payload that contains information on new service |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#create-global-service-200) | OK | successfully created service |  | [schema](#create-global-service-200-schema) |
@@ -423,7 +435,8 @@ Status: OK
 PUT /api/namespaces/{namespace}
 ```
 
-Creates a new namespace
+Creates a new namespace.
+
 
 #### Parameters
 
@@ -432,6 +445,7 @@ Creates a new namespace
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace to create |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#create-namespace-200) | OK | namespace has been successfully created |  | [schema](#create-namespace-200-schema) |
@@ -450,10 +464,11 @@ Status: OK
 POST /api/functions/namespaces/{namespace}
 ```
 
-Creates namespace scoped knative service
-Service Names are unique on a scope level
+Creates namespace scoped knative service.
+Service Names are unique on a scope level.
 These services can be used as functions in workflows, more about this can be read here:
 https://docs.direktiv.io/docs/walkthrough/using-functions.html
+
 
 #### Parameters
 
@@ -463,6 +478,7 @@ https://docs.direktiv.io/docs/walkthrough/using-functions.html
 | Service | `body` | [CreateNamespaceServiceBody](#create-namespace-service-body) | `CreateNamespaceServiceBody` | | ✓ | | Payload that contains information on new service |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#create-namespace-service-200) | OK | successfully created service |  | [schema](#create-namespace-service-200-schema) |
@@ -502,7 +518,8 @@ Status: OK
 PUT /api/namespaces/{namespace}/secrets/{secret}
 ```
 
-Create a namespace secret
+Create a namespace secret.
+
 
 #### Parameters
 
@@ -513,6 +530,7 @@ Create a namespace secret
 | Secret Payload | `body` | [CreateSecretBody](#create-secret-body) | `CreateSecretBody` | |  | | Payload that contains secret data |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#create-secret-200) | OK | successfully created namespace secret |  | [schema](#create-secret-200-schema) |
@@ -548,8 +566,9 @@ Status: OK
 PUT /api/namespaces/{namespace}/tree/{workflow}?op=create-workflow
 ```
 
-Creates a workflow at the target path
-The body of this request should contain the workflow yaml
+Creates a workflow at the target path.
+The body of this request should contain the workflow yaml.
+
 
 #### Consumes
   * text/plain
@@ -563,6 +582,7 @@ The body of this request should contain the workflow yaml
 | workflow data | `body` | string | `string` | |  | | Payload that contains the direktiv workflow yaml to create. |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#create-workflow-200) | OK | successfully created workflow |  | [schema](#create-workflow-200-schema) |
@@ -581,10 +601,11 @@ Status: OK
 DELETE /api/functions/{serviceName}/revisions/{revisionGeneration}
 ```
 
-Delete a global scoped knative service revision
-The target revision generation is the number suffix on a revision
-Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
-Note: Revisions with traffic cannot be deleted
+Delete a global scoped knative service revision.
+The target revision generation is the number suffix on a revision.
+Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'.
+Note: Revisions with traffic cannot be deleted.
+
 
 #### Parameters
 
@@ -594,6 +615,7 @@ Note: Revisions with traffic cannot be deleted
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#delete-global-revision-200) | OK | successfully deleted service revision |  | [schema](#delete-global-revision-200-schema) |
@@ -612,7 +634,8 @@ Status: OK
 DELETE /api/functions/{serviceName}
 ```
 
-Deletes global scoped knative service and all its revisions
+Deletes global scoped knative service and all its revisions.
+
 
 #### Parameters
 
@@ -621,6 +644,7 @@ Deletes global scoped knative service and all its revisions
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#delete-global-service-200) | OK | successfully deleted service |  | [schema](#delete-global-service-200-schema) |
@@ -639,7 +663,8 @@ Status: OK
 DELETE /api/namespaces/{namespace}/instances/{instance}/vars/{variable}
 ```
 
-Delete a instance variable
+Delete a instance variable.
+
 
 #### Parameters
 
@@ -650,6 +675,7 @@ Delete a instance variable
 | variable | `path` | string | `string` |  | ✓ |  | target variable |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#delete-instance-variable-200) | OK | successfully deleted instance variable |  | [schema](#delete-instance-variable-200-schema) |
@@ -668,7 +694,8 @@ Status: OK
 DELETE /api/namespaces/{namespace}
 ```
 
-Delete a namespace
+Delete a namespace.
+
 
 #### Parameters
 
@@ -677,6 +704,7 @@ Delete a namespace
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace to delete |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#delete-namespace-200) | OK | namespace has been successfully deleted |  | [schema](#delete-namespace-200-schema) |
@@ -695,10 +723,11 @@ Status: OK
 DELETE /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}
 ```
 
-Delete a namespace scoped knative service revision
-The target revision generation is the number suffix on a revision
-Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
-Note: Revisions with traffic cannot be deleted
+Delete a namespace scoped knative service revision.
+The target revision generation is the number suffix on a revision.
+Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'.
+Note: Revisions with traffic cannot be deleted.
+
 
 #### Parameters
 
@@ -709,6 +738,7 @@ Note: Revisions with traffic cannot be deleted
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#delete-namespace-revision-200) | OK | successfully deleted service revision |  | [schema](#delete-namespace-revision-200-schema) |
@@ -727,7 +757,8 @@ Status: OK
 DELETE /api/functions/namespaces/{namespace}/function/{serviceName}
 ```
 
-Deletes namespace scoped knative service and all its revisions
+Deletes namespace scoped knative service and all its revisions.
+
 
 #### Parameters
 
@@ -737,6 +768,7 @@ Deletes namespace scoped knative service and all its revisions
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#delete-namespace-service-200) | OK | successfully deleted service |  | [schema](#delete-namespace-service-200-schema) |
@@ -755,7 +787,8 @@ Status: OK
 DELETE /api/namespaces/{namespace}/vars/{variable}
 ```
 
-Delete a namespace variable
+Delete a namespace variable.
+
 
 #### Parameters
 
@@ -765,6 +798,7 @@ Delete a namespace variable
 | variable | `path` | string | `string` |  | ✓ |  | target variable |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#delete-namespace-variable-200) | OK | successfully deleted namespace variable |  | [schema](#delete-namespace-variable-200-schema) |
@@ -785,6 +819,7 @@ POST /api/namespaces/{namespace}/registries
 
 Delete a namespace container registry
 
+
 #### Parameters
 
 | Name | Source | Type | Go type | Separator | Required | Default | Description |
@@ -793,6 +828,7 @@ Delete a namespace container registry
 | Registry Payload | `body` | [DeleteRegistryBody](#delete-registry-body) | `DeleteRegistryBody` | |  | | Payload that contains registry data |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#delete-registry-200) | OK | successfully delete namespace registry |  | [schema](#delete-registry-200-schema) |
@@ -828,7 +864,8 @@ Status: OK
 DELETE /api/namespaces/{namespace}/secrets/{secret}
 ```
 
-Delete a namespace secret
+Delete a namespace secret.
+
 
 #### Parameters
 
@@ -838,6 +875,7 @@ Delete a namespace secret
 | secret | `path` | string | `string` |  | ✓ |  | target secret |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#delete-secret-200) | OK | successfully deleted namespace secret |  | [schema](#delete-secret-200-schema) |
@@ -856,7 +894,8 @@ Status: OK
 DELETE /api/namespaces/{namespace}/tree/{workflow}?op=delete-var
 ```
 
-Delete a workflow variable
+Delete a workflow variable.
+
 
 #### Parameters
 
@@ -867,6 +906,7 @@ Delete a workflow variable
 | var | `query` | string | `string` |  | ✓ |  | target variable |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#delete-workflow-variable-200) | OK | successfully deleted workflow variable |  | [schema](#delete-workflow-variable-200-schema) |
@@ -885,7 +925,8 @@ Status: OK
 POST /api/namespaces/{namespace}/tree/{workflow}?op=execute
 ```
 
-Executes a workflow with optionally some input provided in the request body as json
+Executes a workflow with optionally some input provided in the request body as json.
+
 
 #### Parameters
 
@@ -896,6 +937,7 @@ Executes a workflow with optionally some input provided in the request body as j
 | Workflow Input | `body` | [interface{}](#interface) | `interface{}` | |  | | The input of this workflow instance |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#execute-workflow-200) | OK | successfully executed workflow |  | [schema](#execute-workflow-200-schema) |
@@ -914,7 +956,8 @@ Status: OK
 GET /api/functions/{serviceName}
 ```
 
-Get details of a global scoped knative service
+Get details of a global scoped knative service.
+
 
 #### Parameters
 
@@ -923,6 +966,7 @@ Get details of a global scoped knative service
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-global-service-200) | OK | successfully got service details |  | [schema](#get-global-service-200-schema) |
@@ -941,9 +985,11 @@ Status: OK
 GET /api/functions
 ```
 
-Gets a list of global knative services
+Gets a list of global knative services.
+
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-global-service-list-200) | OK | successfully got services list |  | [schema](#get-global-service-list-200-schema) |
@@ -962,7 +1008,8 @@ Status: OK
 GET /api/namespaces/{namespace}/instances/{instance}
 ```
 
-Gets the details of a executed workflow instance in this namespace
+Gets the details of a executed workflow instance in this namespace.
+
 
 #### Parameters
 
@@ -972,6 +1019,7 @@ Gets the details of a executed workflow instance in this namespace
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-instance-200) | OK | successfully got instance |  | [schema](#get-instance-200-schema) |
@@ -990,7 +1038,8 @@ Status: OK
 GET /api/namespaces/{namespace}/instances/{instance}/input
 ```
 
-Gets the input an instance was provided when executed
+Gets the input an instance was provided when executed.
+
 
 #### Parameters
 
@@ -1000,6 +1049,7 @@ Gets the input an instance was provided when executed
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-instance-input-200) | OK | successfully got instance input |  | [schema](#get-instance-input-200-schema) |
@@ -1018,7 +1068,8 @@ Status: OK
 GET /api/namespaces/{namespace}/instances
 ```
 
-Gets a list of instances in a namespace
+Gets a list of instances in a namespace.
+
 
 #### Parameters
 
@@ -1027,6 +1078,7 @@ Gets a list of instances in a namespace
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-instance-list-200) | OK | successfully got namespace instances |  | [schema](#get-instance-list-200-schema) |
@@ -1045,7 +1097,8 @@ Status: OK
 GET /api/namespaces/{namespace}/instances/{instance}/output
 ```
 
-Gets the output an instance was provided when executed
+Gets the output an instance was provided when executed.
+
 
 #### Parameters
 
@@ -1055,6 +1108,7 @@ Gets the output an instance was provided when executed
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-instance-output-200) | OK | successfully got instance output |  | [schema](#get-instance-output-200-schema) |
@@ -1073,7 +1127,8 @@ Status: OK
 GET /api/namespaces/{namespace}/instances/{instance}/vars/{variable}
 ```
 
-Get the value sorted in a instance variable
+Get the value sorted in a instance variable.
+
 
 #### Parameters
 
@@ -1084,6 +1139,7 @@ Get the value sorted in a instance variable
 | variable | `path` | string | `string` |  | ✓ |  | target variable |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-instance-variable-200) | OK | successfully got instance variable |  | [schema](#get-instance-variable-200-schema) |
@@ -1102,7 +1158,8 @@ Status: OK
 GET /api/namespaces/{namespace}/instances/{instance}/vars
 ```
 
-Gets a list of variables in a instance
+Gets a list of variables in a instance.
+
 
 #### Parameters
 
@@ -1112,6 +1169,7 @@ Gets a list of variables in a instance
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-instance-variables-200) | OK | successfully got instance variables |  | [schema](#get-instance-variables-200-schema) |
@@ -1130,7 +1188,8 @@ Status: OK
 GET /api/functions/namespaces/{namespace}/function/{serviceName}
 ```
 
-Get details of a namespace scoped knative service
+Get details of a namespace scoped knative service.
+
 
 #### Parameters
 
@@ -1140,6 +1199,7 @@ Get details of a namespace scoped knative service
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-namespace-service-200) | OK | successfully got service details |  | [schema](#get-namespace-service-200-schema) |
@@ -1158,7 +1218,8 @@ Status: OK
 GET /api/functions/namespaces/{namespace}
 ```
 
-Gets a list of namespace knative services
+Gets a list of namespace knative services.
+
 
 #### Parameters
 
@@ -1167,6 +1228,7 @@ Gets a list of namespace knative services
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-namespace-service-list-200) | OK | successfully got services list |  | [schema](#get-namespace-service-list-200-schema) |
@@ -1185,7 +1247,8 @@ Status: OK
 GET /api/namespaces/{namespace}/vars/{variable}
 ```
 
-Get the value sorted in a namespace variable
+Get the value sorted in a namespace variable.
+
 
 #### Parameters
 
@@ -1195,6 +1258,7 @@ Get the value sorted in a namespace variable
 | variable | `path` | string | `string` |  | ✓ |  | target variable |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-namespace-variable-200) | OK | successfully got namespace variable |  | [schema](#get-namespace-variable-200-schema) |
@@ -1213,7 +1277,8 @@ Status: OK
 GET /api/namespaces/{namespace}/vars
 ```
 
-Gets a list of variables in a namespace
+Gets a list of variables in a namespace.
+
 
 #### Parameters
 
@@ -1222,6 +1287,7 @@ Gets a list of variables in a namespace
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-namespace-variables-200) | OK | successfully got namespace variables |  | [schema](#get-namespace-variables-200-schema) |
@@ -1240,7 +1306,8 @@ Status: OK
 GET /api/namespaces
 ```
 
-Gets the list of namespaces
+Gets the list of namespaces.
+
 
 #### Parameters
 
@@ -1257,6 +1324,7 @@ Gets the list of namespaces
 | order.field | `query` | string | `string` |  |  |  |  |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-namespaces-200) | OK | successfully got list of namespaces |  | [schema](#get-namespaces-200-schema) |
@@ -1275,7 +1343,8 @@ Status: OK
 GET /api/namespaces/{namespace}/tree/{nodePath}
 ```
 
-Gets Workflow and Directory Nodes at nodePath
+Gets Workflow and Directory Nodes at nodePath.
+
 
 #### Parameters
 
@@ -1285,6 +1354,7 @@ Gets Workflow and Directory Nodes at nodePath
 | nodePath | `path` | int32 (formatted string) | `string` |  | ✓ |  | target path in tree |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-nodes-200) | OK | successfully got namespace nodes |  | [schema](#get-nodes-200-schema) |
@@ -1303,7 +1373,8 @@ Status: OK
 GET /api/namespaces/{namespace}/registries
 ```
 
-Gets the list of namespace registries
+Gets the list of namespace registries.
+
 
 #### Parameters
 
@@ -1312,6 +1383,7 @@ Gets the list of namespace registries
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-registries-200) | OK | successfully got namespace registries |  | [schema](#get-registries-200-schema) |
@@ -1330,7 +1402,8 @@ Status: OK
 GET /api/namespaces/{namespace}/secrets
 ```
 
-Gets the list of namespace secrets
+Gets the list of namespace secrets.
+
 
 #### Parameters
 
@@ -1339,6 +1412,7 @@ Gets the list of namespace secrets
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-secrets-200) | OK | successfully got namespace secrets |  | [schema](#get-secrets-200-schema) |
@@ -1357,7 +1431,8 @@ Status: OK
 GET /api/namespaces/{namespace}/tree/{workflow}?op=logs
 ```
 
-Get workflow level logs
+Get workflow level logs.
+
 
 #### Parameters
 
@@ -1367,6 +1442,7 @@ Get workflow level logs
 | workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-workflow-logs-200) | OK | successfully got workflow logs |  | [schema](#get-workflow-logs-200-schema) |
@@ -1385,8 +1461,9 @@ Status: OK
 GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function
 ```
 
-Get a workflow scoped knative service details
-Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+Get a workflow scoped knative service details.
+Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
+
 
 #### Parameters
 
@@ -1398,6 +1475,7 @@ Note: This is a Server-Sent-Event endpoint, and will not work with the default s
 | version | `query` | string | `string` |  | ✓ |  | target service version |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-workflow-service-200) | OK | successfully got service details |  | [schema](#get-workflow-service-200-schema) |
@@ -1416,10 +1494,11 @@ Status: OK
 GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revision
 ```
 
-Get a workflow scoped knative service revision
-This will return details on a single revision
-The target revision generation (rev query) is the number suffix on a revision
-Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'
+Get a workflow scoped knative service revision.
+This will return details on a single revision.
+The target revision generation (rev query) is the number suffix on a revision.
+Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'.
+
 
 #### Parameters
 
@@ -1431,6 +1510,7 @@ Example: A revisions named 'workflow-10640097968065193909-get-00001' would have 
 | svn | `query` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-workflow-service-revision-200) | OK | successfully got service revision details |  | [schema](#get-workflow-service-revision-200-schema) |
@@ -1449,7 +1529,8 @@ Status: OK
 GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revisions
 ```
 
-Get the revision list of a workflow scoped knative service
+Get the revision list of a workflow scoped knative service.
+
 
 #### Parameters
 
@@ -1461,6 +1542,7 @@ Get the revision list of a workflow scoped knative service
 | version | `query` | string | `string` |  | ✓ |  | target service version |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-workflow-service-revision-list-200) | OK | successfully got service revisions |  | [schema](#get-workflow-service-revision-list-200-schema) |
@@ -1479,7 +1561,8 @@ Status: OK
 GET /api/namespaces/{namespace}/tree/{workflow}?op=var
 ```
 
-Get the value sorted in a workflow variable
+Get the value sorted in a workflow variable.
+
 
 #### Parameters
 
@@ -1490,6 +1573,7 @@ Get the value sorted in a workflow variable
 | var | `query` | string | `string` |  | ✓ |  | target variable |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-workflow-variable-200) | OK | successfully got workflow variable |  | [schema](#get-workflow-variable-200-schema) |
@@ -1508,7 +1592,8 @@ Status: OK
 GET /api/namespaces/{namespace}/tree/{workflow}?op=vars
 ```
 
-Gets a list of variables in a workflow
+Gets a list of variables in a workflow.
+
 
 #### Parameters
 
@@ -1518,6 +1603,7 @@ Gets a list of variables in a workflow
 | workflow | `path` | int32 (formatted string) | `string` |  | ✓ |  | path to target workflow |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#get-workflow-variables-200) | OK | successfully got workflow variables |  | [schema](#get-workflow-variables-200-schema) |
@@ -1536,7 +1622,8 @@ Status: OK
 GET /api/namespaces/{namespace}/instances/{instance}/logs
 ```
 
-Gets the logs of an executed instance
+Gets the logs of an executed instance.
+
 
 #### Parameters
 
@@ -1546,6 +1633,7 @@ Gets the logs of an executed instance
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#instance-logs-200) | OK | successfully got instance logs |  | [schema](#instance-logs-200-schema) |
@@ -1564,8 +1652,8 @@ Status: OK
 POST /api/jq
 ```
 
-JQ Playground is a sandbox where
-you can test jq queries with custom data
+JQ Playground is a sandbox where you can test jq queries with custom data.
+
 
 #### Parameters
 
@@ -1574,6 +1662,7 @@ you can test jq queries with custom data
 | JQ payload | `body` | [JqPlaygroundBody](#jq-playground-body) | `JqPlaygroundBody` | |  | | Payload that contains both the JSON data to manipulate and jq query. |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#jq-playground-200) | OK | jq query was successful |  | [schema](#jq-playground-200-schema) |
@@ -1610,9 +1699,10 @@ Status: OK
 GET /api/functions/{serviceName}/revisions/{revisionGeneration}/pods
 ```
 
-List a revisions pods of a global scoped knative service
-The target revision generation is the number suffix on a revision
-Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
+List a revisions pods of a global scoped knative service.
+The target revision generation is the number suffix on a revision.
+Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003' .
+
 
 #### Parameters
 
@@ -1622,6 +1712,7 @@ Example: A revisions named 'global-fast-request-00003' would have the revisionGe
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#list-global-service-revision-pods-200) | OK | successfully got list of a service revision pods |  | [schema](#list-global-service-revision-pods-200-schema) |
@@ -1640,9 +1731,10 @@ Status: OK
 GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}/pods
 ```
 
-List a revisions pods of a namespace scoped knative service
-The target revision generation is the number suffix on a revision
-Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
+List a revisions pods of a namespace scoped knative service.
+The target revision generation is the number suffix on a revision.
+Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'.
+
 
 #### Parameters
 
@@ -1653,6 +1745,7 @@ Example: A revisions named 'namespace-direktiv-fast-request-00003' would have th
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#list-namespace-service-revision-pods-200) | OK | successfully got list of a service revision pods |  | [schema](#list-namespace-service-revision-pods-200-schema) |
@@ -1671,9 +1764,10 @@ Status: OK
 GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=pods
 ```
 
-List a revisions pods of a workflow scoped knative service
-The target revision generation (rev query) is the number suffix on a revision
-Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'
+List a revisions pods of a workflow scoped knative service.
+The target revision generation (rev query) is the number suffix on a revision.
+Example: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'.
+
 
 #### Parameters
 
@@ -1685,6 +1779,7 @@ Example: A revisions named 'workflow-10640097968065193909-get-00001' would have 
 | svn | `query` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#list-workflow-service-revision-pods-200) | OK | successfully got list of a service revision pods |  | [schema](#list-workflow-service-revision-pods-200-schema) |
@@ -1703,7 +1798,8 @@ Status: OK
 GET /api/functions/namespaces/{namespace}/tree/{workflow}?op=services
 ```
 
-Gets a list of workflow knative services
+Gets a list of workflow knative services.
+
 
 #### Parameters
 
@@ -1713,6 +1809,7 @@ Gets a list of workflow knative services
 | workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#list-workflow-services-200) | OK | successfully got services list |  | [schema](#list-workflow-services-200-schema) |
@@ -1731,7 +1828,8 @@ Status: OK
 GET /api/namespaces/{namespace}/logs
 ```
 
-Gets Namespace Level Logs
+Gets Namespace Level Logs.
+
 
 #### Parameters
 
@@ -1740,6 +1838,7 @@ Gets Namespace Level Logs
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#namespace-logs-200) | OK | successfully got namespace logs |  | [schema](#namespace-logs-200-schema) |
@@ -1758,7 +1857,8 @@ Status: OK
 GET /api/namespaces/{namespace}/metrics/failed
 ```
 
-Get metrics of failed workflows in the targeted namespace
+Get metrics of failed workflows in the targeted namespace.
+
 
 #### Parameters
 
@@ -1767,6 +1867,7 @@ Get metrics of failed workflows in the targeted namespace
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#namespace-metrics-failed-200) | OK | successfully got namespace metrics |  | [schema](#namespace-metrics-failed-200-schema) |
@@ -1785,7 +1886,8 @@ Status: OK
 GET /api/namespaces/{namespace}/metrics/invoked
 ```
 
-Get metrics of invoked workflows in the targeted namespace
+Get metrics of invoked workflows in the targeted namespace.
+
 
 #### Parameters
 
@@ -1794,6 +1896,7 @@ Get metrics of invoked workflows in the targeted namespace
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#namespace-metrics-invoked-200) | OK | successfully got namespace metrics |  | [schema](#namespace-metrics-invoked-200-schema) |
@@ -1812,7 +1915,8 @@ Status: OK
 GET /api/namespaces/{namespace}/metrics/milliseconds
 ```
 
-Get timing metrics of workflows in the targeted namespace
+Get timing metrics of workflows in the targeted namespace.
+
 
 #### Parameters
 
@@ -1821,6 +1925,7 @@ Get timing metrics of workflows in the targeted namespace
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#namespace-metrics-milliseconds-200) | OK | successfully got namespace metrics |  | [schema](#namespace-metrics-milliseconds-200-schema) |
@@ -1839,7 +1944,8 @@ Status: OK
 GET /api/namespaces/{namespace}/metrics/successful
 ```
 
-Get metrics of successful workflows in the targeted namespace
+Get metrics of successful workflows in the targeted namespace.
+
 
 #### Parameters
 
@@ -1848,6 +1954,7 @@ Get metrics of successful workflows in the targeted namespace
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#namespace-metrics-successful-200) | OK | successfully got namespace metrics |  | [schema](#namespace-metrics-successful-200-schema) |
@@ -1866,7 +1973,8 @@ Status: OK
 GET /api/logs
 ```
 
-Gets Direktiv Server Logs
+Gets Direktiv Server Logs.
+
 
 #### Parameters
 
@@ -1883,6 +1991,7 @@ Gets Direktiv Server Logs
 | order.field | `query` | string | `string` |  |  |  |  |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#server-logs-200) | OK | successfully got server logs |  | [schema](#server-logs-200-schema) |
@@ -1901,9 +2010,10 @@ Status: OK
 PUT /api/namespaces/{namespace}/instances/{instance}/vars/{variable}
 ```
 
-Set the value sorted in a instance variable
-If the target variable does not exists, it will be created
-Variable data can be anything so long as it can be represented as a string
+Set the value sorted in a instance variable.
+If the target variable does not exists, it will be created.
+Variable data can be anything so long as it can be represented as a string.
+
 
 #### Consumes
   * text/plain
@@ -1918,6 +2028,7 @@ Variable data can be anything so long as it can be represented as a string
 | data | `body` | string | `string` | |  | | Payload that contains variable data. |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#set-instance-variable-200) | OK | successfully set instance variable |  | [schema](#set-instance-variable-200-schema) |
@@ -1936,9 +2047,10 @@ Status: OK
 PUT /api/namespaces/{namespace}/vars/{variable}
 ```
 
-Set the value sorted in a namespace variable
-If the target variable does not exists, it will be created
-Variable data can be anything so long as it can be represented as a string
+Set the value sorted in a namespace variable.
+If the target variable does not exists, it will be created.
+Variable data can be anything so long as it can be represented as a string.
+
 
 #### Consumes
   * text/plain
@@ -1952,6 +2064,7 @@ Variable data can be anything so long as it can be represented as a string
 | data | `body` | string | `string` | |  | | Payload that contains variable data. |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#set-namespace-variable-200) | OK | successfully set namespace variable |  | [schema](#set-namespace-variable-200-schema) |
@@ -1970,12 +2083,12 @@ Status: OK
 POST /api/namespaces/{namespace}/tree/{workflow}?op=set-workflow-event-logging
 ```
 
-Set Cloud Event for Workflow to Log to
-When configured type `direktiv.instanceLog` cloud events will be generated with the `logger` parameter set to the
-conifgured value
-Workflows can be configured to generate cloud events on their namespace
-anything the log parameter produces data. Please find more information on this topic below:
+Set Cloud Event for Workflow to Log to.
+When configured type `direktiv.instanceLog` cloud events will be generated with the `logger` parameter set to the configured value.
+Workflows can be configured to generate cloud events on their namespace anything the log parameter produces data.
+Please find more information on this topic here:
 https://docs.direktiv.io/docs/examples/logging.html
+
 
 #### Parameters
 
@@ -1986,6 +2099,7 @@ https://docs.direktiv.io/docs/examples/logging.html
 | Cloud Event Logger | `body` | [SetWorkflowCloudEventLogsBody](#set-workflow-cloud-event-logs-body) | `SetWorkflowCloudEventLogsBody` | |  | | Cloud event logger to target |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#set-workflow-cloud-event-logs-200) | OK | successfully update workflow |  | [schema](#set-workflow-cloud-event-logs-200-schema) |
@@ -2021,9 +2135,10 @@ Status: OK
 PUT /api/namespaces/{namespace}/tree/{workflow}?op=set-var
 ```
 
-Set the value sorted in a workflow variable
-If the target variable does not exists, it will be created
-Variable data can be anything so long as it can be represented as a string
+Set the value sorted in a workflow variable.
+If the target variable does not exists, it will be created.
+Variable data can be anything so long as it can be represented as a string.
+
 
 #### Consumes
   * text/plain
@@ -2038,6 +2153,7 @@ Variable data can be anything so long as it can be represented as a string
 | data | `body` | string | `string` | |  | | Payload that contains variable data. |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#set-workflow-variable-200) | OK | successfully set workflow variable |  | [schema](#set-workflow-variable-200-schema) |
@@ -2056,8 +2172,9 @@ Status: OK
 POST /api/namespaces/{namespace}/tree/{workflow}?op=toggle
 ```
 
-Toggle's whether or not a workflow is active
-Disabled workflows cannot be invoked
+Toggle's whether or not a workflow is active.
+Disabled workflows cannot be invoked. This includes start event and scheduled workflows.
+
 
 #### Parameters
 
@@ -2068,6 +2185,7 @@ Disabled workflows cannot be invoked
 | Workflow Live Status | `body` | [ToggleWorkflowBody](#toggle-workflow-body) | `ToggleWorkflowBody` | |  | | Whether or not the workflow is alive or disabled |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#toggle-workflow-200) | OK | successfully updated workflow live status |  | [schema](#toggle-workflow-200-schema) |
@@ -2104,9 +2222,9 @@ POST /api/functions/{serviceName}
 ```
 
 Creates a new global scoped knative service revision
-Revisions are created with a traffic percentage. This percentage controls
-how much traffic will be directed to this revision. Traffic can be set to 100
-to direct all traffic
+Revisions are created with a traffic percentage. This percentage controls how much traffic will be directed to this revision.
+Traffic can be set to 100 to direct all traffic.
+
 
 #### Parameters
 
@@ -2116,6 +2234,7 @@ to direct all traffic
 | Service | `body` | [UpdateGlobalServiceBody](#update-global-service-body) | `UpdateGlobalServiceBody` | | ✓ | | Payload that contains information on service revision |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#update-global-service-200) | OK | successfully created service revision |  | [schema](#update-global-service-200-schema) |
@@ -2155,8 +2274,9 @@ Status: OK
 PATCH /api/functions/{serviceName}
 ```
 
-traffic can only be configured between two revisions. All other revisions
-will bet set to 0 traffic
+Update Global Service traffic directed to each revision, traffic can only be configured between two revisions.
+All other revisions will bet set to 0 traffic.
+
 
 #### Parameters
 
@@ -2166,6 +2286,7 @@ will bet set to 0 traffic
 | Service Traffic | `body` | [UpdateGlobalServiceTrafficBody](#update-global-service-traffic-body) | `UpdateGlobalServiceTrafficBody` | | ✓ | | Payload that contains information on service traffic |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#update-global-service-traffic-200) | OK | successfully updated service traffic |  | [schema](#update-global-service-traffic-200-schema) |
@@ -2217,10 +2338,11 @@ Status: OK
 POST /api/functions/namespaces/{namespace}/function/{serviceName}
 ```
 
-Creates a new namespace scoped knative service revision
+Creates a new namespace scoped knative service revision.
 Revisions are created with a traffic percentage. This percentage controls
 how much traffic will be directed to this revision. Traffic can be set to 100
-to direct all traffic
+to direct all traffic.
+
 
 #### Parameters
 
@@ -2231,6 +2353,7 @@ to direct all traffic
 | Service | `body` | [UpdateNamespaceServiceBody](#update-namespace-service-body) | `UpdateNamespaceServiceBody` | | ✓ | | Payload that contains information on service revision |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#update-namespace-service-200) | OK | successfully created service revision |  | [schema](#update-namespace-service-200-schema) |
@@ -2270,8 +2393,10 @@ Status: OK
 PATCH /api/functions/namespaces/{namespace}/function/{serviceName}
 ```
 
+Update Namespace Service traffic directed to each revision,
 traffic can only be configured between two revisions. All other revisions
-will bet set to 0 traffic
+will bet set to 0 traffic.
+
 
 #### Parameters
 
@@ -2282,6 +2407,7 @@ will bet set to 0 traffic
 | Service Traffic | `body` | [UpdateNamespaceServiceTrafficBody](#update-namespace-service-traffic-body) | `UpdateNamespaceServiceTrafficBody` | | ✓ | | Payload that contains information on service traffic |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#update-namespace-service-traffic-200) | OK | successfully updated service traffic |  | [schema](#update-namespace-service-traffic-200-schema) |
@@ -2333,8 +2459,9 @@ Status: OK
 POST /api/namespaces/{namespace}/tree/{workflow}?op=update-workflow
 ```
 
-Updates a workflow at the target path
-The body of this request should contain the workflow yaml you want to update to
+Updates a workflow at the target path.
+The body of this request should contain the workflow yaml you want to update to.
+
 
 #### Consumes
   * text/plain
@@ -2348,6 +2475,7 @@ The body of this request should contain the workflow yaml you want to update to
 | workflow data | `body` | string | `string` | |  | | Payload that contains the updated direktiv workflow yaml. |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#update-workflow-200) | OK | successfully updated workflow |  | [schema](#update-workflow-200-schema) |
@@ -2366,10 +2494,11 @@ Status: OK
 GET /api/functions/{serviceName}/revisions/{revisionGeneration}
 ```
 
-Watch a global scoped knative service revision
-The target revision generation is the number suffix on a revision
-Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'
-Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+Watch a global scoped knative service revision.
+The target revision generation is the number suffix on a revision.
+Example: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'.
+Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
+
 
 #### Produces
   * text/event-stream
@@ -2382,6 +2511,7 @@ Note: This is a Server-Sent-Event endpoint, and will not work with the default s
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#watch-global-service-revision-200) | OK | successfully watching service revision |  | [schema](#watch-global-service-revision-200-schema) |
@@ -2400,8 +2530,9 @@ Status: OK
 GET /api/functions/{serviceName}/revisions
 ```
 
-Watch the revision list of a global scoped knative service
-Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+Watch the revision list of a global scoped knative service.
+Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
+
 
 #### Produces
   * text/event-stream
@@ -2413,6 +2544,7 @@ Note: This is a Server-Sent-Event endpoint, and will not work with the default s
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#watch-global-service-revision-list-200) | OK | successfully watching service revisions |  | [schema](#watch-global-service-revision-list-200-schema) |
@@ -2431,10 +2563,11 @@ Status: OK
 GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}
 ```
 
-Watch a namespace scoped knative service revision
-The target revision generation is the number suffix on a revision
-Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'
-Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+Watch a namespace scoped knative service revision.
+The target revision generation is the number suffix on a revision.
+Example: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'.
+Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
+
 
 #### Produces
   * text/event-stream
@@ -2448,6 +2581,7 @@ Note: This is a Server-Sent-Event endpoint, and will not work with the default s
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#watch-namespace-service-revision-200) | OK | successfully watching service revision |  | [schema](#watch-namespace-service-revision-200-schema) |
@@ -2466,8 +2600,9 @@ Status: OK
 GET /api/functions/namespaces/{namespace}/function/{serviceName}/revisions
 ```
 
-Watch the revision list of a namespace scoped knative service
-Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client
+Watch the revision list of a namespace scoped knative service.
+Note: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.
+
 
 #### Produces
   * text/event-stream
@@ -2480,6 +2615,7 @@ Note: This is a Server-Sent-Event endpoint, and will not work with the default s
 | serviceName | `path` | string | `string` |  | ✓ |  | target service name |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#watch-namespace-service-revision-list-200) | OK | successfully watching service revisions |  | [schema](#watch-namespace-service-revision-list-200-schema) |
@@ -2498,7 +2634,8 @@ Status: OK
 GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-invoked
 ```
 
-Get metrics of invoked workflow instances
+Get metrics of invoked workflow instances.
+
 
 #### Parameters
 
@@ -2508,6 +2645,7 @@ Get metrics of invoked workflow instances
 | workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#workflow-metrics-invoked-200) | OK | successfully got workflow metrics |  | [schema](#workflow-metrics-invoked-200-schema) |
@@ -2526,8 +2664,9 @@ Status: OK
 GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-failed
 ```
 
-Get the timing metrics of a workflow's instance
-This returns a total sum of the milliseconds a workflow has been executed for
+Get the timing metrics of a workflow's instance.
+This returns a total sum of the milliseconds a workflow has been executed for.
+
 
 #### Parameters
 
@@ -2537,6 +2676,7 @@ This returns a total sum of the milliseconds a workflow has been executed for
 | workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#workflow-metrics-milliseconds-200) | OK | successfully got workflow metrics |  | [schema](#workflow-metrics-milliseconds-200-schema) |
@@ -2555,8 +2695,9 @@ Status: OK
 GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-state-milliseconds
 ```
 
-Get the state timing metrics of a workflow's instance
-The returns the timing of a individual states in a workflow
+Get the state timing metrics of a workflow's instance.
+This returns the timing of individual states in a workflow.
+
 
 #### Parameters
 
@@ -2566,6 +2707,7 @@ The returns the timing of a individual states in a workflow
 | workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#workflow-metrics-state-milliseconds-200) | OK | successfully got workflow metrics |  | [schema](#workflow-metrics-state-milliseconds-200-schema) |
@@ -2584,7 +2726,8 @@ Status: OK
 GET /api/namespaces/{namespace}/tree/{workflow}?op=metrics-successful
 ```
 
-Get metrics of a workflow, where the instance was successful
+Get metrics of a workflow, where the instance was successful.
+
 
 #### Parameters
 
@@ -2594,6 +2737,7 @@ Get metrics of a workflow, where the instance was successful
 | workflow | `path` | string | `string` |  | ✓ |  | path to target workflow |
 
 #### All responses
+
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 | [200](#workflow-metrics-successful-200) | OK | successfully got workflow metrics |  | [schema](#workflow-metrics-successful-200-schema) |

--- a/scripts/api/api.md
+++ b/scripts/api/api.md
@@ -527,7 +527,7 @@ Create a namespace secret.
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 | secret | `path` | string | `string` |  | ✓ |  | target secret |
-| Secret Payload | `body` | [CreateSecretBody](#create-secret-body) | `CreateSecretBody` | |  | | Payload that contains secret data |
+| Secret Payload | `body` | string | `string` | |  | | Payload that contains secret data. |
 
 #### All responses
 
@@ -542,23 +542,6 @@ Create a namespace secret.
 Status: OK
 
 ###### <span id="create-secret-200-schema"></span> Schema
-
-###### Inlined models
-
-**<span id="create-secret-body"></span> CreateSecretBody**
-
-
-  
-
-
-
-**Properties**
-
-| Name | Type | Go type | Required | Default | Description | Example |
-|------|------|---------|:--------:| ------- |-------------|---------|
-| data | string| `string` | ✓ | | Secret data to be set |  |
-
-
 
 ### <span id="create-workflow"></span> Create a Workflow (*createWorkflow*)
 

--- a/scripts/api/swagger.json
+++ b/scripts/api/swagger.json
@@ -22,7 +22,7 @@
   "paths": {
     "/api/functions": {
       "get": {
-        "description": "Gets a list of global knative services",
+        "description": "Gets a list of global knative services.\n",
         "tags": [
           "Global Services"
         ],
@@ -35,7 +35,7 @@
         }
       },
       "post": {
-        "description": "Creates global scoped knative service\nService Names are unique on a scope level\nThese services can be used as functions in workflows, more about this can be read here:\nhttps://docs.direktiv.io/docs/walkthrough/using-functions.html",
+        "description": "Creates global scoped knative service.\nService Names are unique on a scope level.\nThese services can be used as functions in workflows, more about this can be read here:\nhttps://docs.direktiv.io/docs/walkthrough/using-functions.html\n",
         "tags": [
           "Global Services"
         ],
@@ -101,7 +101,7 @@
     },
     "/api/functions/namespaces/{namespace}": {
       "get": {
-        "description": "Gets a list of namespace knative services",
+        "description": "Gets a list of namespace knative services.\n",
         "tags": [
           "Namespace Services"
         ],
@@ -123,7 +123,7 @@
         }
       },
       "post": {
-        "description": "Creates namespace scoped knative service\nService Names are unique on a scope level\nThese services can be used as functions in workflows, more about this can be read here:\nhttps://docs.direktiv.io/docs/walkthrough/using-functions.html",
+        "description": "Creates namespace scoped knative service.\nService Names are unique on a scope level.\nThese services can be used as functions in workflows, more about this can be read here:\nhttps://docs.direktiv.io/docs/walkthrough/using-functions.html\n",
         "tags": [
           "Namespace Services"
         ],
@@ -196,7 +196,7 @@
     },
     "/api/functions/namespaces/{namespace}/function/{serviceName}": {
       "get": {
-        "description": "Get details of a namespace scoped knative service",
+        "description": "Get details of a namespace scoped knative service.\n",
         "tags": [
           "Namespace Services"
         ],
@@ -225,7 +225,7 @@
         }
       },
       "post": {
-        "description": "Creates a new namespace scoped knative service revision\nRevisions are created with a traffic percentage. This percentage controls\nhow much traffic will be directed to this revision. Traffic can be set to 100\nto direct all traffic",
+        "description": "Creates a new namespace scoped knative service revision.\nRevisions are created with a traffic percentage. This percentage controls\nhow much traffic will be directed to this revision. Traffic can be set to 100\nto direct all traffic.\n",
         "tags": [
           "Namespace Services"
         ],
@@ -303,7 +303,7 @@
         }
       },
       "delete": {
-        "description": "Deletes namespace scoped knative service and all its revisions",
+        "description": "Deletes namespace scoped knative service and all its revisions.\n",
         "tags": [
           "Namespace Services"
         ],
@@ -332,7 +332,7 @@
         }
       },
       "patch": {
-        "description": "traffic can only be configured between two revisions. All other revisions\nwill bet set to 0 traffic",
+        "description": "Update Namespace Service traffic directed to each revision,\ntraffic can only be configured between two revisions. All other revisions\nwill bet set to 0 traffic.\n",
         "tags": [
           "Namespace Services"
         ],
@@ -406,7 +406,7 @@
     },
     "/api/functions/namespaces/{namespace}/function/{serviceName}/revisions": {
       "get": {
-        "description": "Watch the revision list of a namespace scoped knative service\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
+        "description": "Watch the revision list of a namespace scoped knative service.\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.\n",
         "produces": [
           "text/event-stream"
         ],
@@ -440,7 +440,7 @@
     },
     "/api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}": {
       "get": {
-        "description": "Watch a namespace scoped knative service revision\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
+        "description": "Watch a namespace scoped knative service revision.\nThe target revision generation is the number suffix on a revision.\nExample: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'.\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.\n",
         "produces": [
           "text/event-stream"
         ],
@@ -479,7 +479,7 @@
         }
       },
       "delete": {
-        "description": "Delete a namespace scoped knative service revision\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'\nNote: Revisions with traffic cannot be deleted",
+        "description": "Delete a namespace scoped knative service revision.\nThe target revision generation is the number suffix on a revision.\nExample: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'.\nNote: Revisions with traffic cannot be deleted.\n",
         "tags": [
           "Namespace Services"
         ],
@@ -517,7 +517,7 @@
     },
     "/api/functions/namespaces/{namespace}/function/{serviceName}/revisions/{revisionGeneration}/pods": {
       "get": {
-        "description": "List a revisions pods of a namespace scoped knative service\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'",
+        "description": "List a revisions pods of a namespace scoped knative service.\nThe target revision generation is the number suffix on a revision.\nExample: A revisions named 'namespace-direktiv-fast-request-00003' would have the revisionGeneration '00003'.\n",
         "tags": [
           "Namespace Services"
         ],
@@ -555,7 +555,7 @@
     },
     "/api/functions/namespaces/{namespace}/tree/{workflow}?op=function": {
       "get": {
-        "description": "Get a workflow scoped knative service details\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
+        "description": "Get a workflow scoped knative service details.\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.\n",
         "tags": [
           "Workflow Services"
         ],
@@ -600,7 +600,7 @@
     },
     "/api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revision": {
       "get": {
-        "description": "Get a workflow scoped knative service revision\nThis will return details on a single revision\nThe target revision generation (rev query) is the number suffix on a revision\nExample: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'",
+        "description": "Get a workflow scoped knative service revision.\nThis will return details on a single revision.\nThe target revision generation (rev query) is the number suffix on a revision.\nExample: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'.\n",
         "tags": [
           "Workflow Services"
         ],
@@ -645,7 +645,7 @@
     },
     "/api/functions/namespaces/{namespace}/tree/{workflow}?op=function-revisions": {
       "get": {
-        "description": "Get the revision list of a workflow scoped knative service",
+        "description": "Get the revision list of a workflow scoped knative service.\n",
         "tags": [
           "Workflow Services"
         ],
@@ -690,7 +690,7 @@
     },
     "/api/functions/namespaces/{namespace}/tree/{workflow}?op=pods": {
       "get": {
-        "description": "List a revisions pods of a workflow scoped knative service\nThe target revision generation (rev query) is the number suffix on a revision\nExample: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'",
+        "description": "List a revisions pods of a workflow scoped knative service.\nThe target revision generation (rev query) is the number suffix on a revision.\nExample: A revisions named 'workflow-10640097968065193909-get-00001' would have the revisionGeneration '00001'.\n",
         "tags": [
           "Workflow Services"
         ],
@@ -735,7 +735,7 @@
     },
     "/api/functions/namespaces/{namespace}/tree/{workflow}?op=services": {
       "get": {
-        "description": "Gets a list of workflow knative services",
+        "description": "Gets a list of workflow knative services.\n",
         "tags": [
           "Workflow Services"
         ],
@@ -766,7 +766,7 @@
     },
     "/api/functions/{serviceName}": {
       "get": {
-        "description": "Get details of a global scoped knative service",
+        "description": "Get details of a global scoped knative service.\n",
         "tags": [
           "Global Services"
         ],
@@ -788,7 +788,7 @@
         }
       },
       "post": {
-        "description": "Creates a new global scoped knative service revision\nRevisions are created with a traffic percentage. This percentage controls\nhow much traffic will be directed to this revision. Traffic can be set to 100\nto direct all traffic",
+        "description": "Creates a new global scoped knative service revision\nRevisions are created with a traffic percentage. This percentage controls how much traffic will be directed to this revision.\nTraffic can be set to 100 to direct all traffic.\n",
         "tags": [
           "Global Services"
         ],
@@ -859,7 +859,7 @@
         }
       },
       "delete": {
-        "description": "Deletes global scoped knative service and all its revisions",
+        "description": "Deletes global scoped knative service and all its revisions.\n",
         "tags": [
           "Global Services"
         ],
@@ -881,7 +881,7 @@
         }
       },
       "patch": {
-        "description": "traffic can only be configured between two revisions. All other revisions\nwill bet set to 0 traffic",
+        "description": "Update Global Service traffic directed to each revision, traffic can only be configured between two revisions.\nAll other revisions will bet set to 0 traffic.\n",
         "tags": [
           "Global Services"
         ],
@@ -948,7 +948,7 @@
     },
     "/api/functions/{serviceName}/revisions": {
       "get": {
-        "description": "Watch the revision list of a global scoped knative service\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
+        "description": "Watch the revision list of a global scoped knative service.\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.\n",
         "produces": [
           "text/event-stream"
         ],
@@ -975,7 +975,7 @@
     },
     "/api/functions/{serviceName}/revisions/{revisionGeneration}": {
       "get": {
-        "description": "Watch a global scoped knative service revision\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client",
+        "description": "Watch a global scoped knative service revision.\nThe target revision generation is the number suffix on a revision.\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'.\nNote: This is a Server-Sent-Event endpoint, and will not work with the default swagger client.\n",
         "produces": [
           "text/event-stream"
         ],
@@ -1007,7 +1007,7 @@
         }
       },
       "delete": {
-        "description": "Delete a global scoped knative service revision\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'\nNote: Revisions with traffic cannot be deleted",
+        "description": "Delete a global scoped knative service revision.\nThe target revision generation is the number suffix on a revision.\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'.\nNote: Revisions with traffic cannot be deleted.\n",
         "tags": [
           "Global Services"
         ],
@@ -1038,7 +1038,7 @@
     },
     "/api/functions/{serviceName}/revisions/{revisionGeneration}/pods": {
       "get": {
-        "description": "List a revisions pods of a global scoped knative service\nThe target revision generation is the number suffix on a revision\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003'",
+        "description": "List a revisions pods of a global scoped knative service.\nThe target revision generation is the number suffix on a revision.\nExample: A revisions named 'global-fast-request-00003' would have the revisionGeneration '00003' .\n",
         "tags": [
           "Global Services"
         ],
@@ -1069,7 +1069,7 @@
     },
     "/api/jq": {
       "post": {
-        "description": "JQ Playground is a sandbox where\nyou can test jq queries with custom data",
+        "description": "JQ Playground is a sandbox where you can test jq queries with custom data.\n",
         "tags": [
           "Other"
         ],
@@ -1112,7 +1112,7 @@
     },
     "/api/logs": {
       "get": {
-        "description": "Gets Direktiv Server Logs",
+        "description": "Gets Direktiv Server Logs.\n",
         "tags": [
           "Logs"
         ],
@@ -1185,7 +1185,7 @@
     },
     "/api/namespaces": {
       "get": {
-        "description": "Gets the list of namespaces",
+        "description": "Gets the list of namespaces.\n",
         "tags": [
           "Namespaces"
         ],
@@ -1258,7 +1258,7 @@
     },
     "/api/namespaces/{namespace}": {
       "put": {
-        "description": "Creates a new namespace",
+        "description": "Creates a new namespace.\n",
         "tags": [
           "Namespaces"
         ],
@@ -1280,7 +1280,7 @@
         }
       },
       "delete": {
-        "description": "Delete a namespace",
+        "description": "Delete a namespace.\n",
         "tags": [
           "Namespaces"
         ],
@@ -1304,7 +1304,7 @@
     },
     "/api/namespaces/{namespace}/broadcast": {
       "post": {
-        "description": "Broadcast a cloud event to a namespace\nCloud events posted to this api will be picked up by any workflows listening to the same event type on the namescape.\nThe body of this request should follow the cloud event core specification defined at https://github.com/cloudevents/spec",
+        "description": "Broadcast a cloud event to a namespace.\nCloud events posted to this api will be picked up by any workflows listening to the same event type on the namescape.\nThe body of this request should follow the cloud event core specification defined at https://github.com/cloudevents/spec .\n",
         "tags": [
           "Other"
         ],
@@ -1336,7 +1336,7 @@
     },
     "/api/namespaces/{namespace}/instances": {
       "get": {
-        "description": "Gets a list of instances in a namespace",
+        "description": "Gets a list of instances in a namespace.\n",
         "tags": [
           "Instances"
         ],
@@ -1360,7 +1360,7 @@
     },
     "/api/namespaces/{namespace}/instances/{instance}": {
       "get": {
-        "description": "Gets the details of a executed workflow instance in this namespace",
+        "description": "Gets the details of a executed workflow instance in this namespace.\n",
         "tags": [
           "Instances"
         ],
@@ -1391,7 +1391,7 @@
     },
     "/api/namespaces/{namespace}/instances/{instance}/cancel": {
       "post": {
-        "description": "Cancel a currently pending instance",
+        "description": "Cancel a currently pending instance.\n",
         "tags": [
           "Instances"
         ],
@@ -1422,7 +1422,7 @@
     },
     "/api/namespaces/{namespace}/instances/{instance}/input": {
       "get": {
-        "description": "Gets the input an instance was provided when executed",
+        "description": "Gets the input an instance was provided when executed.\n",
         "tags": [
           "Instances"
         ],
@@ -1453,7 +1453,7 @@
     },
     "/api/namespaces/{namespace}/instances/{instance}/logs": {
       "get": {
-        "description": "Gets the logs of an executed instance",
+        "description": "Gets the logs of an executed instance.\n",
         "tags": [
           "Logs"
         ],
@@ -1487,7 +1487,7 @@
     },
     "/api/namespaces/{namespace}/instances/{instance}/output": {
       "get": {
-        "description": "Gets the output an instance was provided when executed",
+        "description": "Gets the output an instance was provided when executed.\n",
         "tags": [
           "Instances"
         ],
@@ -1518,7 +1518,7 @@
     },
     "/api/namespaces/{namespace}/instances/{instance}/vars": {
       "get": {
-        "description": "Gets a list of variables in a instance",
+        "description": "Gets a list of variables in a instance.\n",
         "tags": [
           "Variables"
         ],
@@ -1552,7 +1552,7 @@
     },
     "/api/namespaces/{namespace}/instances/{instance}/vars/{variable}": {
       "get": {
-        "description": "Get the value sorted in a instance variable",
+        "description": "Get the value sorted in a instance variable.\n",
         "tags": [
           "Variables"
         ],
@@ -1588,7 +1588,7 @@
         }
       },
       "put": {
-        "description": "Set the value sorted in a instance variable\nIf the target variable does not exists, it will be created\nVariable data can be anything so long as it can be represented as a string",
+        "description": "Set the value sorted in a instance variable.\nIf the target variable does not exists, it will be created.\nVariable data can be anything so long as it can be represented as a string.\n",
         "consumes": [
           "text/plain"
         ],
@@ -1638,7 +1638,7 @@
         }
       },
       "delete": {
-        "description": "Delete a instance variable",
+        "description": "Delete a instance variable.\n",
         "tags": [
           "Variables"
         ],
@@ -1676,7 +1676,7 @@
     },
     "/api/namespaces/{namespace}/logs": {
       "get": {
-        "description": "Gets Namespace Level Logs",
+        "description": "Gets Namespace Level Logs.\n",
         "tags": [
           "Logs"
         ],
@@ -1701,7 +1701,7 @@
     },
     "/api/namespaces/{namespace}/metrics/failed": {
       "get": {
-        "description": "Get metrics of failed workflows in the targeted namespace",
+        "description": "Get metrics of failed workflows in the targeted namespace.\n",
         "tags": [
           "Metrics"
         ],
@@ -1725,7 +1725,7 @@
     },
     "/api/namespaces/{namespace}/metrics/invoked": {
       "get": {
-        "description": "Get metrics of invoked workflows in the targeted namespace",
+        "description": "Get metrics of invoked workflows in the targeted namespace.\n",
         "tags": [
           "Metrics"
         ],
@@ -1749,7 +1749,7 @@
     },
     "/api/namespaces/{namespace}/metrics/milliseconds": {
       "get": {
-        "description": "Get timing metrics of workflows in the targeted namespace",
+        "description": "Get timing metrics of workflows in the targeted namespace.\n",
         "tags": [
           "Metrics"
         ],
@@ -1773,7 +1773,7 @@
     },
     "/api/namespaces/{namespace}/metrics/successful": {
       "get": {
-        "description": "Get metrics of successful workflows in the targeted namespace",
+        "description": "Get metrics of successful workflows in the targeted namespace.\n",
         "tags": [
           "Metrics"
         ],
@@ -1797,7 +1797,7 @@
     },
     "/api/namespaces/{namespace}/registries": {
       "get": {
-        "description": "Gets the list of namespace registries",
+        "description": "Gets the list of namespace registries.\n",
         "tags": [
           "Registries"
         ],
@@ -1820,7 +1820,7 @@
         }
       },
       "post": {
-        "description": "Delete a namespace container registry",
+        "description": "Delete a namespace container registry\n",
         "tags": [
           "Registries"
         ],
@@ -1865,7 +1865,7 @@
     },
     "/api/namespaces/{namespace}/secrets": {
       "get": {
-        "description": "Gets the list of namespace secrets",
+        "description": "Gets the list of namespace secrets.\n",
         "tags": [
           "Secrets"
         ],
@@ -1890,7 +1890,7 @@
     },
     "/api/namespaces/{namespace}/secrets/{secret}": {
       "put": {
-        "description": "Create a namespace secret",
+        "description": "Create a namespace secret.\n",
         "tags": [
           "Secrets"
         ],
@@ -1939,7 +1939,7 @@
         }
       },
       "delete": {
-        "description": "Delete a namespace secret",
+        "description": "Delete a namespace secret.\n",
         "tags": [
           "Secrets"
         ],
@@ -1970,7 +1970,7 @@
     },
     "/api/namespaces/{namespace}/tree/{directory}?op=create-directory": {
       "put": {
-        "description": "Creates a directory at the target path",
+        "description": "Creates a directory at the target path.\n",
         "tags": [
           "Directory"
         ],
@@ -2001,7 +2001,7 @@
     },
     "/api/namespaces/{namespace}/tree/{nodePath}": {
       "get": {
-        "description": "Gets Workflow and Directory Nodes at nodePath",
+        "description": "Gets Workflow and Directory Nodes at nodePath.\n",
         "tags": [
           "Directory",
           "Workflows"
@@ -2036,7 +2036,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=create-workflow": {
       "put": {
-        "description": "Creates a workflow at the target path\nThe body of this request should contain the workflow yaml",
+        "description": "Creates a workflow at the target path.\nThe body of this request should contain the workflow yaml.\n",
         "consumes": [
           "text/plain"
         ],
@@ -2079,7 +2079,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=delete-var": {
       "delete": {
-        "description": "Delete a workflow variable",
+        "description": "Delete a workflow variable.\n",
         "tags": [
           "Variables"
         ],
@@ -2117,7 +2117,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=execute": {
       "post": {
-        "description": "Executes a workflow with optionally some input provided in the request body as json",
+        "description": "Executes a workflow with optionally some input provided in the request body as json.\n",
         "tags": [
           "Workflows"
         ],
@@ -2163,7 +2163,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=logs": {
       "get": {
-        "description": "Get workflow level logs",
+        "description": "Get workflow level logs.\n",
         "tags": [
           "Logs"
         ],
@@ -2194,7 +2194,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=metrics-failed": {
       "get": {
-        "description": "Get the timing metrics of a workflow's instance\nThis returns a total sum of the milliseconds a workflow has been executed for",
+        "description": "Get the timing metrics of a workflow's instance.\nThis returns a total sum of the milliseconds a workflow has been executed for.\n",
         "tags": [
           "Metrics"
         ],
@@ -2225,7 +2225,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=metrics-invoked": {
       "get": {
-        "description": "Get metrics of invoked workflow instances",
+        "description": "Get metrics of invoked workflow instances.\n",
         "tags": [
           "Metrics"
         ],
@@ -2256,7 +2256,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=metrics-state-milliseconds": {
       "get": {
-        "description": "Get the state timing metrics of a workflow's instance\nThe returns the timing of a individual states in a workflow",
+        "description": "Get the state timing metrics of a workflow's instance.\nThis returns the timing of individual states in a workflow.\n",
         "tags": [
           "Metrics"
         ],
@@ -2287,7 +2287,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=metrics-successful": {
       "get": {
-        "description": "Get metrics of a workflow, where the instance was successful",
+        "description": "Get metrics of a workflow, where the instance was successful.\n",
         "tags": [
           "Metrics"
         ],
@@ -2318,7 +2318,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=set-var": {
       "put": {
-        "description": "Set the value sorted in a workflow variable\nIf the target variable does not exists, it will be created\nVariable data can be anything so long as it can be represented as a string",
+        "description": "Set the value sorted in a workflow variable.\nIf the target variable does not exists, it will be created.\nVariable data can be anything so long as it can be represented as a string.\n",
         "consumes": [
           "text/plain"
         ],
@@ -2370,7 +2370,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=set-workflow-event-logging": {
       "post": {
-        "description": "Set Cloud Event for Workflow to Log to\nWhen configured type `direktiv.instanceLog` cloud events will be generated with the `logger` parameter set to the\nconifgured value\nWorkflows can be configured to generate cloud events on their namespace\nanything the log parameter produces data. Please find more information on this topic below:\nhttps://docs.direktiv.io/docs/examples/logging.html",
+        "description": "Set Cloud Event for Workflow to Log to.\nWhen configured type `direktiv.instanceLog` cloud events will be generated with the `logger` parameter set to the configured value.\nWorkflows can be configured to generate cloud events on their namespace anything the log parameter produces data.\nPlease find more information on this topic here:\nhttps://docs.direktiv.io/docs/examples/logging.html\n",
         "tags": [
           "Workflows"
         ],
@@ -2421,7 +2421,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=toggle": {
       "post": {
-        "description": "Toggle's whether or not a workflow is active\nDisabled workflows cannot be invoked",
+        "description": "Toggle's whether or not a workflow is active.\nDisabled workflows cannot be invoked. This includes start event and scheduled workflows.\n",
         "tags": [
           "Workflows"
         ],
@@ -2472,7 +2472,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=update-workflow": {
       "post": {
-        "description": "Updates a workflow at the target path\nThe body of this request should contain the workflow yaml you want to update to",
+        "description": "Updates a workflow at the target path.\nThe body of this request should contain the workflow yaml you want to update to.\n",
         "consumes": [
           "text/plain"
         ],
@@ -2515,7 +2515,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=var": {
       "get": {
-        "description": "Get the value sorted in a workflow variable",
+        "description": "Get the value sorted in a workflow variable.\n",
         "tags": [
           "Variables"
         ],
@@ -2553,7 +2553,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=vars": {
       "get": {
-        "description": "Gets a list of variables in a workflow",
+        "description": "Gets a list of variables in a workflow.\n",
         "tags": [
           "Variables"
         ],
@@ -2587,7 +2587,7 @@
     },
     "/api/namespaces/{namespace}/tree/{workflow}?op=wait": {
       "get": {
-        "description": "Executes a workflow. This path will wait until the workflow execution has completed and return the instance output\nNOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json\nkey. Only top level json keys are supported when providing input with query parameters",
+        "description": "Executes a workflow. This path will wait until the workflow execution has completed and return the instance output.\nNOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json key.\nOnly top level json keys are supported when providing input with query parameters.\n",
         "tags": [
           "Workflows"
         ],
@@ -2634,7 +2634,7 @@
         }
       },
       "post": {
-        "description": "Executes a workflow with optionally some input provided in the request body as json\nThis path will wait until the workflow execution has completed and return the instance output\nNOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json\nkey. Only top level json keys are supported when providing input with query parameters. Input query\nparameters are only read if the request has not body",
+        "description": "Executes a workflow with optionally some input provided in the request body as json.\nThis path will wait until the workflow execution has completed and return the instance output.\nNOTE: Input can also be provided with the `input.X` query parameters; Where `X` is the json key.\nOnly top level json keys are supported when providing input with query parameters.\nInput query parameters are only read if the request has no body.\n",
         "tags": [
           "Workflows"
         ],
@@ -2698,7 +2698,7 @@
     },
     "/api/namespaces/{namespace}/vars": {
       "get": {
-        "description": "Gets a list of variables in a namespace",
+        "description": "Gets a list of variables in a namespace.\n",
         "tags": [
           "Variables"
         ],
@@ -2723,7 +2723,7 @@
     },
     "/api/namespaces/{namespace}/vars/{variable}": {
       "get": {
-        "description": "Get the value sorted in a namespace variable",
+        "description": "Get the value sorted in a namespace variable.\n",
         "tags": [
           "Variables"
         ],
@@ -2752,7 +2752,7 @@
         }
       },
       "put": {
-        "description": "Set the value sorted in a namespace variable\nIf the target variable does not exists, it will be created\nVariable data can be anything so long as it can be represented as a string",
+        "description": "Set the value sorted in a namespace variable.\nIf the target variable does not exists, it will be created.\nVariable data can be anything so long as it can be represented as a string.\n",
         "consumes": [
           "text/plain"
         ],
@@ -2795,7 +2795,7 @@
         }
       },
       "delete": {
-        "description": "Delete a namespace variable",
+        "description": "Delete a namespace variable.\n",
         "tags": [
           "Variables"
         ],

--- a/scripts/api/swagger.json
+++ b/scripts/api/swagger.json
@@ -1891,6 +1891,9 @@
     "/api/namespaces/{namespace}/secrets/{secret}": {
       "put": {
         "description": "Create a namespace secret.\n",
+        "consumes": [
+          "text/plain"
+        ],
         "tags": [
           "Secrets"
         ],
@@ -1912,23 +1915,12 @@
             "required": true
           },
           {
-            "description": "Payload that contains secret data",
+            "description": "Payload that contains secret data.",
             "name": "Secret Payload",
             "in": "body",
             "schema": {
-              "type": "object",
-              "required": [
-                "data"
-              ],
-              "properties": {
-                "data": {
-                  "description": "Secret data to be set",
-                  "type": "string"
-                }
-              },
-              "example": {
-                "data": "8QwFLg%D$qg*3r++`{D\u003cBAp~4mB49^"
-              }
+              "type": "string",
+              "example": "7F8E7B0124ACB2BD20B383DE0756C7C0"
             }
           }
         ],


### PR DESCRIPTION
Signed-off-by: Jon Alfaro <jon.alfaro@vorteil.io>

## Description

- Doc comments updated so that generated markdown can work with jekyll
- Makefile api-docs target updated to fix generated markdown
- Small corrections to api docs
