### PR TITLE
Changes to docker build on makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,16 +134,17 @@ build/%-binary: Makefile ${GO_SOURCE_FILES}
    	touch $@; \
 	fi
 
-build/%.md5: build/%-binary
-	@echo "Calculating md5 checkum of $<..."
-	@md5sum $< build/docker/$*/Dockerfile > $@
+# build/%.md5: build/%-binary
+# 	@echo "Calculating md5 checkum of $<..."
+# 	@md5sum $< build/docker/$*/Dockerfile > $@
 
-build/%-docker.checksum: build/%.md5 ${DOCKER_FILES}
-	@set -e ; if ! cmp --silent build/$*.md5 build/$*-docker.checksum; then echo "Building docker image for $* binary..." && cd build && docker build -t direktiv-$* -f docker/$*/Dockerfile . ; else echo "Skipping docker build due to unchanged $* binary." && touch build/$*-docker.checksum; fi
-	@cp build/$*.md5 build/$*-docker.checksum
+# build/%-docker.checksum: build/%.md5 ${DOCKER_FILES}
+# 	@set -e ; if ! cmp --silent build/$*.md5 build/$*-docker.checksum; then echo "Building docker image for $* binary..." && cd build && docker build -t direktiv-$* -f docker/$*/Dockerfile . ; else echo "Skipping docker build due to unchanged $* binary." && touch build/$*-docker.checksum; fi
+# 	@cp build/$*.md5 build/$*-docker.checksum
 
 .PHONY: image-%
-image-%: build/%-docker.checksum
+image-%: build/%-binary
+	cd build && DOCKER_BUILDKIT=1 docker build -t direktiv-$* -f docker/$*/Dockerfile .
 	@echo "Make $@: SUCCESS"
 
 RELEASE := ""

--- a/Makefile
+++ b/Makefile
@@ -134,14 +134,6 @@ build/%-binary: Makefile ${GO_SOURCE_FILES}
    	touch $@; \
 	fi
 
-# build/%.md5: build/%-binary
-# 	@echo "Calculating md5 checkum of $<..."
-# 	@md5sum $< build/docker/$*/Dockerfile > $@
-
-# build/%-docker.checksum: build/%.md5 ${DOCKER_FILES}
-# 	@set -e ; if ! cmp --silent build/$*.md5 build/$*-docker.checksum; then echo "Building docker image for $* binary..." && cd build && docker build -t direktiv-$* -f docker/$*/Dockerfile . ; else echo "Skipping docker build due to unchanged $* binary." && touch build/$*-docker.checksum; fi
-# 	@cp build/$*.md5 build/$*-docker.checksum
-
 .PHONY: image-%
 image-%: build/%-binary
 	cd build && DOCKER_BUILDKIT=1 docker build -t direktiv-$* -f docker/$*/Dockerfile .


### PR DESCRIPTION
## Description

When using `make docker-all` i realised using ```make cluster``` then ends up sending 2.4GiB of build context to the docker build command.

When researching we stumbled upon buildkit which seems to work for linux machines only. Its smart enough to realise what context each image needs rather than including it all. 

Including DOCKER_BUILDKIT=1 where docker build is called greatly increases build times and fixes context overloading.

-  Make cluster (no checksum check) with buildkit
    - No changes
      - real	0m16.080s
      - user	0m11.762s
      - sys	0m2.866s
    - Changes to API binary 
      - real	0m28.043s
      - user	0m13.033s
      - sys	0m3.042s

-  Make cluster on current main branch
   - No changes
     - real	2m58.315s
     - user	0m46.911s
     - sys	0m17.217s
   - Changes to API binary
     - real	2m13.410s
     - user	0m49.458s
     - sys	0m17.401s
