### PR TITLE
Changes workflow ref regex to be more permissive.

### DIFF
--- a/pkg/flow/ent/schema/ref.go
+++ b/pkg/flow/ent/schema/ref.go
@@ -20,7 +20,7 @@ func (Ref) Fields() []ent.Field {
 	return []ent.Field{
 		field.UUID("id", uuid.UUID{}).Default(uuid.New).Immutable().StorageKey("oid").StructTag(`json:"-"`),
 		field.Bool("immutable").Default(true).Immutable(),
-		field.String("name").Match(NameRegex).Immutable().Annotations(entgql.OrderField("NAME")),
+		field.String("name").Match(RefRegex).Immutable().Annotations(entgql.OrderField("NAME")),
 	}
 }
 

--- a/pkg/flow/ent/schema/regex.go
+++ b/pkg/flow/ent/schema/regex.go
@@ -15,3 +15,9 @@ var URIRegex = regexp.MustCompile(URIRegexPattern)
 const VarNameRegexPattern = `^(([a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9])|([a-zA-Z]))$`
 
 var VarNameRegex = regexp.MustCompile(VarNameRegexPattern)
+
+const RefRegexFragment = `(([a-zA-Z0-9][a-zA-Z0-9_\-\.]*[a-zA-Z0-9])|([a-zA-Z0-9]))`
+
+const RefRegexPattern = `^` + RefRegexFragment + `$`
+
+var RefRegex = regexp.MustCompile(RefRegexPattern)


### PR DESCRIPTION
The workflow 'ref' regex followed our standard naming regex, but in this context that was too restrictive. Refs couldn't begin with a digit, which caused issues because they were being auto-generated from their revision UUIDs (which can begin with numbers). Besides, wanting to tag something as `0.5.0` is perfectly reasonable, and should be made possible. 

Signed-off-by: Alan Murtagh <alan.murtagh@vorteil.io>