### PR TITLE
Rewrite helm github actions workflow to support versioning

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -14,7 +14,6 @@ jobs:
         repository: vorteil/direktiv  # The repository to scan.
         releases-only: false  # We know that all relevant tags have a GitHub release for them.
       id: ptag  # The step ID to refer to later.
-
     - name: build helm chart direktiv
       run: |
         wget https://github.com/zegl/kube-score/releases/download/v1.11.0/kube-score_1.11.0_linux_amd64
@@ -24,34 +23,19 @@ jobs:
         v="${version:1}"
         echo "packaging helm for $v"
         helm dependency update kubernetes/charts/direktiv/
-        helm package --app-version=$v kubernetes/charts/direktiv/
+        helm package --app-version=$v --version=$v kubernetes/charts/direktiv/
         helm dependency update kubernetes/charts/knative
-        helm package --app-version=$v kubernetes/charts/knative/
+        helm package --app-version=$v --version=$v kubernetes/charts/knative/
         git clone https://github.com/CrunchyData/postgres-operator-examples.git
-        helm package postgres-operator-examples/helm/install/
-        helm repo index .
+        helm package --app-version=$v --version=$v postgres-operator-examples/helm/install/
+        wget https://${{ secrets.GCP_BUCKET }}.storage.googleapis.com/charts/index.yaml
+        echo "do helm index thing"
+        helm repo index ./ --merge ./index.yaml
         ls -la
-    - id: upload-file
-      uses: google-github-actions/upload-cloud-storage@main
-      with:
-        credentials: ${{ secrets.GCP_BUCKET }}
-        path: ./index.yaml
-        destination: direktiv_charts/
-    - id: upload-file-tar
-      uses: google-github-actions/upload-cloud-storage@main
-      with:
-        credentials: ${{ secrets.GCP_BUCKET }}
-        path: ./direktiv-0.1.0.tgz
-        destination: direktiv_charts/
-    - id: upload-file-tar-knative
-      uses: google-github-actions/upload-cloud-storage@main
-      with:
-        credentials: ${{ secrets.GCP_BUCKET }}
-        path: ./knative-0.2.0.tgz
-        destination: direktiv_charts/
-    - id: upload-file-tar-pgo
-      uses: google-github-actions/upload-cloud-storage@main
-      with:
-        credentials: ${{ secrets.GCP_BUCKET }}
-        path: ./pgo-0.1.0.tgz
-        destination: direktiv_charts/
+        echo ${{ secrets.GCP_CREDENTIALS }} >> ./gcp.raw
+        base64 --decode ./gcp.raw >> ./gcp.key 
+        gcloud auth activate-service-account --key-file=./gcp.key > /dev/null 2>&1
+        gsutil cp ./direktiv-$v.tgz gs://${{ secrets.GCP_BUCKET }}/charts/direktiv-$v.tgz > /dev/null 2>&1
+        gsutil cp ./knative-$v.tgz gs://${{ secrets.GCP_BUCKET }}/charts/knative-$v.tgz > /dev/null 2>&1
+        gsutil cp ./pgo-$v.tgz gs://${{ secrets.GCP_BUCKET }}/charts/pgo-$v.tgz > /dev/null 2>&1
+        gsutil cp ./index.yaml gs://${{ secrets.GCP_BUCKET }}/charts/index.yaml > /dev/null 2>&1


### PR DESCRIPTION
Changed the Github Actions workflow that published Helm charts to support versioning (previous would simply overwrite the existing chart).

If this PR is accepted, please note that the `GCP_CREDENTIALS` repository secret must be set, to hold the base64-encoded contents of a Google Cloud Platform service account JSON key. `GCP_BUCKET` must equal the name of the bucket as it appears on Google Cloud Platform (ie. `my-bucket`, and NOT `my-bucket/charts`).