### PR TITLE
Wait API with no body data now assumes JSON input even when no input …

### DIFF
--- a/pkg/api/flow.go
+++ b/pkg/api/flow.go
@@ -3032,13 +3032,13 @@ func (h *flowHandler) WaitWorkflow(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-		if len(m) > 0 {
-			input, err = json.Marshal(m)
-			if err != nil {
-				respond(w, nil, err)
-				return
-			}
+
+		input, err = json.Marshal(m)
+		if err != nil {
+			respond(w, nil, err)
+			return
 		}
+
 	}
 
 	in := &grpc.StartWorkflowRequest{


### PR DESCRIPTION
…is provided.

Signed-off-by: Alan Murtagh <alan.murtagh@vorteil.io>

I've decided for GET requests it's fine to assume JSON input. GET requests cannot reasonably handle binary data anyway, and if you really want to you can emulate it by passing `?input.input=`, and setting to base64 encoded binary data.