### PR TITLE
Added a sanitize function to trim the prefix slash from instance name

### DIFF
--- a/pkg/flow/engine.go
+++ b/pkg/flow/engine.go
@@ -116,7 +116,7 @@ func (engine *engine) NewInstance(ctx context.Context, args *newInstanceArgs) (*
 		return nil, err
 	}
 
-	in, err := inc.Create().SetNamespace(d.ns()).SetWorkflow(d.wf).SetRevision(d.rev()).SetRuntime(rt).SetStatus(StatusPending).SetAs(as).Save(ctx)
+	in, err := inc.Create().SetNamespace(d.ns()).SetWorkflow(d.wf).SetRevision(d.rev()).SetRuntime(rt).SetStatus(StatusPending).SetAs(util.SanitizeAsField(as)).Save(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/grpc-util.go
+++ b/pkg/util/grpc-util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"net"
+	"strings"
 	"time"
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
@@ -93,4 +94,13 @@ func GrpcServerOptions(unaryInterceptor grpc.UnaryServerInterceptor, streamInter
 
 	return additionalServerOptions
 
+}
+
+// SanitizeAsField removes initial slash if one exists and returns the new value
+func SanitizeAsField(as string) string {
+	if strings.HasPrefix(as, "/") {
+		newas := strings.TrimPrefix(as, "/")
+		return newas
+	}
+	return as
 }


### PR DESCRIPTION
Maintain consistency between start type even triggered instances and execute instances to list the same. 